### PR TITLE
Enable passing vars to configure_file with flags during build [BUILD-391]

### DIFF
--- a/configure_file.bzl
+++ b/configure_file.bzl
@@ -1,8 +1,17 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
 CMAKE_FALSE_CONSTANTS = ["0", "OFF", "NO", "FALSE", "N", "IGNORE", "NOTFOUND"]
 
 def _configure_file_impl(ctx):
     vars = {}
-    for (key, val) in ctx.attr.vars.items():
+    for var in ctx.attr.vars:
+        key_val = var.split("=")
+        if len(key_val) != 2:
+            # skip if var is not in the right format: <key>=<value>
+            continue
+        key = key_val[0]
+        val = key_val[1]
+
         cmake_define = "#cmakedefine {}".format(key)
         define = "// #undef {}".format(key) if val in CMAKE_FALSE_CONSTANTS else "#define {}".format(key)
 
@@ -21,7 +30,7 @@ def _configure_file_impl(ctx):
 configure_file = rule(
     implementation = _configure_file_impl,
     attrs = {
-        "vars": attr.string_dict(),
+        "vars": attr.string_list(),
         "out": attr.string(),
         "template": attr.label(
             allow_single_file = [".in"],
@@ -29,3 +38,23 @@ configure_file = rule(
         ),
     },
 )
+
+def config_var(var, config):
+    return select({
+        config: [var + "=ON"],
+        "//conditions:default": [var + "=OFF"],
+    })
+
+def var(var, value):
+    return [var + "=" + value]
+
+def config_flag(config, flag):
+    string_flag(
+        name = flag,
+        build_setting_default = "",
+    )
+
+    native.config_setting(
+        name = config,
+        flag_values = {":" + flag: "ON"},
+    )


### PR DESCRIPTION
In Bazel, we can neither concatenate `dict select` ([Bazel ticket](https://github.com/bazelbuild/bazel/issues/12457)):
```
vars = select({
    "//:config-1": {"var1": "ON"},
    "//conditions:default": {"var1": "OFF"},
}) + select({
    "//:config-2": {"var2": "ON"},
    "//conditions:default": {"var2": "OFF"},
}),
```
nor use select inside a dict:
```
vars = {
    "var1": select({
        "//:config-1": "ON",
        "//conditions:default", "OFF"
    }),
    "var2": select({
        "//:config-2": "ON",
        "//conditions:default", "OFF"
    }),
},
```
That's why to enable passing vars to `configure_file`, we have to use list instead of dict.
List which is passed to `configure_file` contains vars in the following format: `<key>=<value>`. Vars which don't contain equal sign are skipped.

I defined a few macros to use `configure_file` in a more elegant way:
`var` -  define var
`config_var` - define var that relies on `config_setting`
`config_flag` - define flag along with `config_setting`

PR tested here:
https://github.com/swift-nav/libpal/pull/275
https://github.com/swift-nav/libswiftnav-private/pull/403
https://github.com/swift-nav/gnss-converters-bazel/pull/8