### PR TITLE
Fixes clang-format rules for new repo structure

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,0 @@
-build:clang-format-check --aspects //bazel/clang_format:clang_format_check.bzl%clang_format_check_aspect
-build:clang-format-check --output_groups=report

--- a/clang_format/.clang-format
+++ b/clang_format/.clang-format
@@ -1,0 +1,9 @@
+# Complete list of style options can be found at:
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+Language:      Cpp
+BasedOnStyle:  Google
+Standard:      Cpp11
+BinPackParameters: false
+BinPackArguments: false 
+...

--- a/clang_format/BUILD
+++ b/clang_format/BUILD
@@ -1,5 +1,16 @@
 load(":choose_clang_format.bzl", "choose_clang_format")
 
+filegroup(
+    name = "clang_format_config_default",
+    srcs = [ ".clang-format" ],
+)
+
+label_flag(
+    name = "clang_format_config",
+    build_setting_default = ":clang_format_config_default",
+    visibility = ["//visibility:public"],
+)
+
 choose_clang_format(
     name = "clang_format_bin",
     visibility = ["//visibility:public"],
@@ -21,7 +32,12 @@ sh_binary(
     ],
     data = [
         ":_clang_format_bin",
-        "//:clang_format_config",
+        ":clang_format_config",
     ],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    glob(["*.bzl"]) + ["run_clang_format.sh"] + [".clang-format"],
     visibility = ["//visibility:public"],
 )

--- a/clang_format/choose_clang_format.bzl
+++ b/clang_format/choose_clang_format.bzl
@@ -1,4 +1,5 @@
 def _choose_clang_format(ctx):
+    print("I'M CHOOSING CLANG FORMAT")
     out = ctx.actions.declare_file("clang_format_bin.sh")
 
     ctx.actions.run_shell(

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -53,8 +53,8 @@ clang_format_check_aspect = aspect(
     implementation = _clang_format_check_aspect_impl,
     fragments = ["cpp"],
     attrs = {
-        "_clang_format": attr.label(default = Label("//bazel/clang_format:clang_format")),
-        "_clang_format_config": attr.label(default = Label("//:clang_format_config")),
-        "_clang_format_bin": attr.label(default = Label("//bazel/clang_format:clang_format_bin")),
+        "_clang_format": attr.label(default = Label("//clang_format:clang_format")),
+        "_clang_format_config": attr.label(default = "//clang_format:clang_format_config"),
+        "_clang_format_bin": attr.label(default = Label("//clang_format:clang_format_bin")),
     },
 )


### PR DESCRIPTION
Fixes up the clang-format PR so that it works with the rules repo refactor.

The `run-clang-format` target works as expected 👍🏼 .

The `clang-format-check` target has a slight error. It doesn't seem to be exporting the default `.clang-format` file as a data dependency. If you override the default and use the `.clang-format` local to the project, then it works as expected.