### PR TITLE
Add FAST_CSV_OPTION_TYPE_SUPPORT define to fast_csv [BUILD-421]

### DIFF
--- a/third_party/fast_csv.BUILD
+++ b/third_party/fast_csv.BUILD
@@ -15,5 +15,6 @@ package(
 cc_library(
     name = "fast_csv",
     hdrs = glob(["**"]),
+    defines = ["FAST_CSV_OPTION_TYPE_SUPPORT"],
     includes = ["."],
 )


### PR DESCRIPTION
This PR moves FAST_CSV_OPTION_TYPE_SUPPORT define to the fast_csv.bzl file.
Tested here:
https://github.com/swift-nav/starling/pull/7155