### PR TITLE
Add macro for setting up local include prefix

### DIFF
--- a/cc/local_include_prefix.bzl
+++ b/cc/local_include_prefix.bzl
@@ -8,9 +8,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-
 def local_include_prefix():
     root = Label(native.repository_name() + "//:WORKSPACE").workspace_root or "."
-    root = root + "/"
-    print(root)
-    return root
+    package = native.package_name()
+    return root + "/" + package + "/"

--- a/cc/local_include_prefix.bzl
+++ b/cc/local_include_prefix.bzl
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+def local_include_prefix():
+    root = Label(native.repository_name() + "//:WORKSPACE").workspace_root or "."
+    root = root + "/"
+    print(root)
+    return root


### PR DESCRIPTION
Defines a macro for setting up the local include prefix so that we don't have to reimplement this logic in every repository.

I've tested it with `libsbp` (as a standalone project), and with `gnss-converters` (using `libsbp` as an external repo), and it works as expected.

I'm also working on integrating this into `swift_cc*` so that these paths get set up automatically but I still need to figure out how to deal with `$(GENDIR)`. See: https://github.com/swift-nav/rules_swiftnav/pull/19.

In the mean time this will do.