### PR TITLE
Fixes for albatross build [BUILD-480]

### DIFF
--- a/third_party/ThreadPool.BUILD
+++ b/third_party/ThreadPool.BUILD
@@ -8,30 +8,12 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-
 package(
     default_visibility = ["//visibility:public"],
 )
 
-string_flag(
-    name = "fast_csv_option_type_support",
-    build_setting_default = "",
-)
-
-config_setting(
-    name = "_fast_csv_option_type_support",
-    flag_values = {
-        ":fast_csv_option_type_support": "on",
-    },
-)
-
 cc_library(
-    name = "fast_csv",
-    hdrs = glob(["**"]),
-    defines = select({
-        ":_fast_csv_option_type_support": ["FAST_CSV_OPTION_TYPE_SUPPORT"],
-        "//conditions:default": [],
-    }),
+    name = "ThreadPool",
+    hdrs = ["ThreadPool.h"],
     includes = ["."],
 )


### PR DESCRIPTION
Fixes two seperate issues to support albatross:

* Adds a build file for ThreadPool, a new third party dependency

* Makes support for optional in fast_csv a configurable attribute.

This is required because albatross does not build with this option enabled, but we have other projects that do.

Testing:

Tested in a build that requires this option and one that does not:
- https://github.com/swift-nav/albatross/pull/379
- https://github.com/swift-nav/starling/pull/7288