### PR TITLE
Fixes for netcdf-cxx stack [BUILD-384]

### DIFF
--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -23,7 +23,6 @@ cc_library(
         [
             "src/**/*.c",
             "hl/src/*.c",
-            "c++/src/*.cpp",
         ],
         exclude = [
             "src/H5make_libsettings.c",
@@ -42,9 +41,7 @@ cc_library(
         ],
     }),
     includes = [
-        "c++/src",
         "config",
-        "hl/src",
         "src",
         "src/H5FDsubfiling",
     ],
@@ -52,6 +49,26 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":header",
+    ],
+)
+
+cc_library(
+    name = "hdf5_hl",
+    srcs = glob(["hl/src/*.c"]),
+    copts = select({
+        "@bazel_tools//src/conditions:windows": [
+            "/Zc:preprocessor-",
+        ],
+        "//conditions:default": [
+            "-Wno-error=implicit-function-declaration",
+        ],
+    }),
+    includes = [
+        "hl/src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":hdf5",
     ],
 )
 

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -36,5 +36,6 @@ cmake(
     visibility = ["//visibility:public"],
     deps = [
         "@hdf5",
+        "@hdf5//:hdf5_hl",
     ],
 )

--- a/third_party/netcdf-cxx.BUILD
+++ b/third_party/netcdf-cxx.BUILD
@@ -24,7 +24,10 @@ cmake(
     cache_entries = {
         "BUILD_SHARED_LIBS": "OFF",
         "NCXX_ENABLE_TESTS": "OFF",
-        "HDF5_C_LIBRARY_hdf5": "libhdf5.a",
+        # This variable is expected to be set by hdf5's cmake build scripts,
+        # but since we're building hdf5 directly in bazel, we have to pass it here.
+        # The value is unimportant to the build unless you need H5free_memory.
+        "HDF5_C_LIBRARY_hdf5": "foo",
     },
     lib_source = ":srcs",
     out_static_libs = ["libnetcdf-cxx4.a"],

--- a/third_party/netcdf-cxx.BUILD
+++ b/third_party/netcdf-cxx.BUILD
@@ -24,9 +24,14 @@ cmake(
     cache_entries = {
         "BUILD_SHARED_LIBS": "OFF",
         "NCXX_ENABLE_TESTS": "OFF",
+        "HDF5_C_LIBRARY_hdf5": "libhdf5.a",
     },
     lib_source = ":srcs",
     out_static_libs = ["libnetcdf-cxx4.a"],
     visibility = ["//visibility:public"],
-    deps = ["@netcdf-c"],
+    deps = [
+        "@hdf5",
+        "@hdf5//:hdf5_hl",
+        "@netcdf-c",
+    ],
 )


### PR DESCRIPTION
Various fixes to the netcdf stack required to get it working:
- Splits hdl5 and hdl5_hl into two separate libraries. This is how the project is typically structured, and netcdf expects a seperate hdf5_hl.a artifact.
- The build rule for netcdfcxx requires hdf5 as explicit dependencies so calls to `find_package` work as expected.