### PR TITLE
clang-tidy-rule: Filter out headers

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -143,7 +143,7 @@ def _clang_tidy_aspect_impl(target, ctx):
     compilation_contexts = _get_compilation_contexts(target, ctx)
 
     srcs = _rule_sources(ctx)
-    unsupported_ext = ["inc"]
+    unsupported_ext = ["inc", "h", "hpp"]
     outputs = []
     for src in srcs:
         if src.extension not in unsupported_ext:

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -143,6 +143,9 @@ def _clang_tidy_aspect_impl(target, ctx):
     compilation_contexts = _get_compilation_contexts(target, ctx)
 
     srcs = _rule_sources(ctx)
+
+    # We exclude headers because we shouldn't run clang-tidy directly with them.
+    # Headers will be linted if included in a source file.
     unsupported_ext = ["inc", "h", "hpp"]
     outputs = []
     for src in srcs:


### PR DESCRIPTION
[Here in gnss-converters](https://github.com/swift-nav/gnss-converters-private/blob/master/c/gnss_converters/BUILD.bazel) we pass headers as source files. In `clang-tidy-rule` we iterate over sources and run clang-tidy on them.

Since a header is not a final compilation unit, we cannot be sure if this will work. If we want to keep passing headers as source files, we have to filter them out in `clang-tidy-rule`.