### PR TITLE
cc: move -Werror to a toolchain feature

### DIFF
--- a/cc/copts.bzl
+++ b/cc/copts.bzl
@@ -1,7 +1,6 @@
 # The following are set by default by Bazel:
 # -Wall, -Wunused-but-set-parameter, -Wno-free-heap-object
 DEFAULT_COPTS = [
-    "-Werror",
     "-Wcast-align",
     "-Wcast-qual",
     "-Wchar-subscripts",

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -63,10 +63,11 @@ def swift_cc_library(**kwargs):
 
     copts = _common_c_opts(nocopts, pedantic = True)
     copts = local_includes + copts
-    kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
+    kwargs["copts"] = copts + kwargs.get("copts", [])
 
-    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
-    kwargs["tags"] = (kwargs["tags"] if "tags" in kwargs else []) + [LIBRARY]
+    kwargs["features"] = _default_features() + kwargs.get("features", [])
+
+    kwargs["tags"] = kwargs.get("tags", []) + [LIBRARY]
 
     native.cc_library(**kwargs)
 
@@ -97,9 +98,9 @@ def swift_cc_tool_library(**kwargs):
 
     copts = _common_c_opts(nocopts, pedantic = False)
     copts = local_includes + copts
-    kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
+    kwargs["copts"] = copts + kwargs.get("copts", [])
 
-    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+    kwargs["features"] = _default_features() + kwargs.get("features", [])
 
     native.cc_library(**kwargs)
 
@@ -129,10 +130,11 @@ def swift_cc_binary(**kwargs):
 
     copts = _common_c_opts(nocopts, pedantic = True)
     copts = local_includes + copts
-    kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
-    kwargs["tags"] = (kwargs["tags"] if "tags" in kwargs else []) + [BINARY]
+    kwargs["copts"] = copts + kwargs.get("copts", [])
 
-    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+    kwargs["features"] = _default_features() + kwargs.get("features", [])
+
+    kwargs["tags"] = kwargs.get("tags", []) + [BINARY]
 
     native.cc_binary(**kwargs)
 
@@ -160,9 +162,9 @@ def swift_cc_tool(**kwargs):
     nocopts = kwargs.pop("nocopts", [])
 
     copts = _common_c_opts(nocopts, pedantic = False)
-    kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
+    kwargs["copts"] = copts + kwargs.get("copts", [])
 
-    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+    kwargs["features"] = _default_features() + kwargs.get("features", [])
 
     native.cc_binary(**kwargs)
 
@@ -183,7 +185,7 @@ def swift_cc_test_library(**kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + local_includes
+    kwargs["copts"] = local_includes + kwargs.get("copts", [])
 
     native.cc_library(**kwargs)
 
@@ -213,7 +215,7 @@ def swift_cc_test(name, type, **kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + local_includes
+    kwargs["copts"] = local_includes + kwargs.get("copts", [])
     kwargs["name"] = name
-    kwargs["tags"] = (kwargs["tags"] if "tags" in kwargs else []) + [type]
+    kwargs["tags"] = [type] + kwargs.get("tags", [])
     native.cc_test(**kwargs)

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -35,7 +35,12 @@ def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
 def _default_features():
-    return ["treat_warnings_as_errors"]
+    return select({
+        # treat_warnings_as_errors passes the option -fatal-warnings
+        # to the linker which ld on mac does not understand.
+        "@platforms//os:macos": [],
+        "//conditions:default": ["treat_warnings_as_errors"],
+    })
 
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -34,6 +34,9 @@ def _common_c_opts(nocopts, pedantic = False):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
+def _default_features():
+    return ["treat_warnings_as_errors"]
+
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
 
@@ -61,6 +64,8 @@ def swift_cc_library(**kwargs):
     copts = _common_c_opts(nocopts, pedantic = True)
     copts = local_includes + copts
     kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
+
+    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
     kwargs["tags"] = (kwargs["tags"] if "tags" in kwargs else []) + [LIBRARY]
 
     native.cc_library(**kwargs)
@@ -94,6 +99,8 @@ def swift_cc_tool_library(**kwargs):
     copts = local_includes + copts
     kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
 
+    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+
     native.cc_library(**kwargs)
 
 def swift_cc_binary(**kwargs):
@@ -125,6 +132,8 @@ def swift_cc_binary(**kwargs):
     kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
     kwargs["tags"] = (kwargs["tags"] if "tags" in kwargs else []) + [BINARY]
 
+    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+
     native.cc_binary(**kwargs)
 
 def swift_cc_tool(**kwargs):
@@ -153,6 +162,8 @@ def swift_cc_tool(**kwargs):
     copts = _common_c_opts(nocopts, pedantic = False)
     kwargs["copts"] = copts + (kwargs["copts"] if "copts" in kwargs else [])
 
+    kwargs["features"] = _default_features() + (kwargs["features"] if "features" in kwargs else [])
+
     native.cc_binary(**kwargs)
 
 def swift_cc_test_library(**kwargs):
@@ -173,6 +184,7 @@ def swift_cc_test_library(**kwargs):
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     kwargs["copts"] = (kwargs["copts"] if "copts" in kwargs else []) + local_includes
+
     native.cc_library(**kwargs)
 
 def swift_cc_test(name, type, **kwargs):


### PR DESCRIPTION
Bazel 6.0 introduces a new toolchain feature;
treat_warnings_as_errors which enables toggling -Werror on a per target basis, as well as at the command line.