### PR TITLE
cc: default to static linking for tests

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -221,6 +221,7 @@ def swift_cc_test(name, type, **kwargs):
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
     kwargs["name"] = name
     kwargs["tags"] = [type] + kwargs.get("tags", [])
     native.cc_test(**kwargs)


### PR DESCRIPTION
According to docs static linking is enabled by default for `cc_binary` but not anything else: https://bazel.build/reference/be/c-cpp#cc_binary.linkstatic.

I think for tests we want to link statically by default.

Also I'm running into some issues on mac where the interpreter can't seem to find the output `.dylib`s in `bazel-out`, causing all the tests to fail. This fixes that issue.