### PR TITLE
Change qac script and add get_target_files aspect [BUILD-506]

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -11,7 +11,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 
 exports_files(
-    glob(["*.bzl"]) + ["qac_compile_commands.sh"],
+    glob(["*.bzl"]) + ["qac_compile_commands.py"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/gen_sonar_cfg.bzl
+++ b/tools/gen_sonar_cfg.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("//tools:get_files.bzl", "FilesInfo", "get_target_files")
+load("//tools:get_cc_files.bzl", "FilesInfo", "get_cc_target_files")
 
 def _gen_sonar_cfg_impl(ctx):
     all_files_bash = ""
@@ -41,7 +41,7 @@ def _gen_sonar_cfg_impl(ctx):
 gen_sonar_cfg = rule(
     implementation = _gen_sonar_cfg_impl,
     attrs = {
-        "targets": attr.label_list(aspects = [get_target_files]),
+        "targets": attr.label_list(aspects = [get_cc_target_files]),
         "test_srcs": attr.label_list(),
         "root_dir": attr.label(default = Label("//tools:root_dir")),
     },

--- a/tools/gen_sonar_cfg.bzl
+++ b/tools/gen_sonar_cfg.bzl
@@ -1,39 +1,5 @@
-load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-
-FilesInfo = provider(
-    fields = {
-        "files": "files of the target",
-    },
-)
-
-def _get_target_files_impl(target, ctx):
-    files = []
-
-    if not CcInfo in target:
-        return [FilesInfo(files = [])]
-
-    tags = getattr(ctx.rule.attr, "tags", [])
-    if not LIBRARY in tags and not TEST_LIBRARY in tags and not BINARY in tags:
-        return [FilesInfo(files = [])]
-
-    if hasattr(ctx.rule.attr, "srcs"):
-        for src in ctx.rule.attr.srcs:
-            for file in src.files.to_list():
-                if file.is_source and not file.path.startswith(ctx.genfiles_dir.path):
-                    files.append(file)
-
-    if hasattr(ctx.rule.attr, "hdrs"):
-        for hdr in ctx.rule.attr.hdrs:
-            for file in hdr.files.to_list():
-                if not file.path.startswith(ctx.genfiles_dir.path):
-                    files.append(file)
-
-    return [FilesInfo(files = files)]
-
-_get_target_files = aspect(
-    implementation = _get_target_files_impl,
-)
+load("//tools:get_files.bzl", "FilesInfo", "get_target_files")
 
 def _gen_sonar_cfg_impl(ctx):
     all_files_bash = ""
@@ -75,7 +41,7 @@ def _gen_sonar_cfg_impl(ctx):
 gen_sonar_cfg = rule(
     implementation = _gen_sonar_cfg_impl,
     attrs = {
-        "targets": attr.label_list(aspects = [_get_target_files]),
+        "targets": attr.label_list(aspects = [get_target_files]),
         "test_srcs": attr.label_list(),
         "root_dir": attr.label(default = Label("//tools:root_dir")),
     },

--- a/tools/get_cc_files.bzl
+++ b/tools/get_cc_files.bzl
@@ -26,7 +26,7 @@ def _get_srcs(ctx):
                     files.append(file)
     return files
 
-def _get_target_files_impl(target, ctx):
+def _get_cc_target_files_impl(target, ctx):
     files = []
 
     if not CcInfo in target:
@@ -42,16 +42,16 @@ def _get_target_files_impl(target, ctx):
 
     return [FilesInfo(files = files)]
 
-get_target_files = aspect(
-    implementation = _get_target_files_impl,
+get_cc_target_files = aspect(
+    implementation = _get_cc_target_files_impl,
 )
 
-def _get_target_hdrs_impl(target, ctx):
+def _get_cc_target_hdrs_impl(target, ctx):
     if not CcInfo in target:
         return [FilesInfo(files = [])]
 
     return [FilesInfo(files = _get_hdrs(ctx))]
 
-get_target_hdrs = aspect(
-    implementation = _get_target_hdrs_impl,
+get_cc_target_hdrs = aspect(
+    implementation = _get_cc_target_hdrs_impl,
 )

--- a/tools/get_files.bzl
+++ b/tools/get_files.bzl
@@ -1,0 +1,57 @@
+load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY")
+
+FilesInfo = provider(
+    fields = {
+        "files": "files of the target",
+    },
+)
+
+def _get_hdrs(ctx):
+    files = []
+
+    if hasattr(ctx.rule.attr, "hdrs"):
+        for hdr in ctx.rule.attr.hdrs:
+            for file in hdr.files.to_list():
+                if not file.path.startswith(ctx.genfiles_dir.path):
+                    files.append(file)
+    return files
+
+def _get_srcs(ctx):
+    files = []
+
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            for file in src.files.to_list():
+                if file.is_source and not file.path.startswith(ctx.genfiles_dir.path):
+                    files.append(file)
+    return files
+
+def _get_target_files_impl(target, ctx):
+    files = []
+
+    if not CcInfo in target:
+        return [FilesInfo(files = [])]
+
+    tags = getattr(ctx.rule.attr, "tags", [])
+    if not LIBRARY in tags and not TEST_LIBRARY in tags and not BINARY in tags:
+        return [FilesInfo(files = [])]
+
+    files.extend(_get_srcs(ctx))
+
+    files.extend(_get_hdrs(ctx))
+
+    return [FilesInfo(files = files)]
+
+get_target_files = aspect(
+    implementation = _get_target_files_impl,
+)
+
+def _get_target_hdrs_impl(target, ctx):
+    if not CcInfo in target:
+        return [FilesInfo(files = [])]
+
+    return [FilesInfo(files = _get_hdrs(ctx))]
+
+get_target_hdrs = aspect(
+    implementation = _get_target_hdrs_impl,
+)

--- a/tools/qac_compile_commands.bzl
+++ b/tools/qac_compile_commands.bzl
@@ -19,9 +19,9 @@ def qac_compile_commands(name, tool, **kwargs):
 
     """
     arg = "$(location {})".format(tool)
-    native.sh_binary(
+    native.py_binary(
         name = name,
-        srcs = [Label("//tools:qac_compile_commands.sh")],
+        srcs = [Label("//tools:qac_compile_commands.py")],
         args = [arg],
         data = [tool],
         **kwargs

--- a/tools/qac_compile_commands.py
+++ b/tools/qac_compile_commands.py
@@ -1,0 +1,30 @@
+import sys, subprocess, json, os
+
+def is_external(path):
+    return path.startswith("external/") or path.find("/bin/external/") != -1
+
+refresh_compile_commands=sys.argv[1]
+workspace_dir = os.getenv('BUILD_WORKSPACE_DIRECTORY')
+
+subprocess.call(refresh_compile_commands, shell=True)
+
+with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_file:
+    compile_commands = json.load(compile_commands_file)
+
+    for compile_command in compile_commands:
+        args = compile_command["arguments"]
+        for i in range(len(args)):
+            if (args[i] == "-iquote" or args[i] == "-I") and is_external(args[i+1]):
+                args[i] = "-isystem"
+            elif args[i] == "-isystem" and not is_external(args[i+1]):
+                args[i] = "-I"
+
+    compile_commands_file.truncate(0)
+    compile_commands_file.seek(0)
+    json.dump(
+        compile_commands,
+        compile_commands_file,
+        indent=2,
+        check_circular=False
+    )
+

--- a/tools/qac_compile_commands.py
+++ b/tools/qac_compile_commands.py
@@ -1,10 +1,12 @@
 import sys, subprocess, json, os
 
+
 def is_external(path):
     return path.startswith("external/") or path.find("/bin/external/") != -1
 
-refresh_compile_commands=sys.argv[1]
-workspace_dir = os.getenv('BUILD_WORKSPACE_DIRECTORY')
+
+refresh_compile_commands = sys.argv[1]
+workspace_dir = os.getenv("BUILD_WORKSPACE_DIRECTORY")
 
 subprocess.call(refresh_compile_commands, shell=True)
 
@@ -14,17 +16,13 @@ with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_fi
     for compile_command in compile_commands:
         args = compile_command["arguments"]
         for i in range(len(args)):
-            if (args[i] == "-iquote" or args[i] == "-I") and is_external(args[i+1]):
+            if i + 1 >= len(args):
+                break
+            if (args[i] == "-iquote" or args[i] == "-I") and is_external(args[i + 1]):
                 args[i] = "-isystem"
-            elif (args[i] == "-isystem" or args[i] == "-iquote") and not is_external(args[i+1]):
+            elif (args[i] == "-isystem") and not is_external(args[i + 1]):
                 args[i] = "-I"
 
     compile_commands_file.truncate(0)
     compile_commands_file.seek(0)
-    json.dump(
-        compile_commands,
-        compile_commands_file,
-        indent=2,
-        check_circular=False
-    )
-
+    json.dump(compile_commands, compile_commands_file, indent=2, check_circular=False)

--- a/tools/qac_compile_commands.py
+++ b/tools/qac_compile_commands.py
@@ -16,7 +16,7 @@ with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_fi
         for i in range(len(args)):
             if (args[i] == "-iquote" or args[i] == "-I") and is_external(args[i+1]):
                 args[i] = "-isystem"
-            elif args[i] == "-isystem" and not is_external(args[i+1]):
+            elif (args[i] == "-isystem" or args[i] == "-iquote") and not is_external(args[i+1]):
                 args[i] = "-I"
 
     compile_commands_file.truncate(0)

--- a/tools/qac_compile_commands.py
+++ b/tools/qac_compile_commands.py
@@ -1,28 +1,38 @@
 import sys, subprocess, json, os
 
+# This script adds the -isystem flag before external include paths
+# and adds the -I flag otherwise. This is needed for Helix QAC
+# to work properly.
+# Usage: qac_compile_commands <REFRESH_COMPILE_COMMANDS>
+
 
 def _is_external(path):
     return path.startswith("external/") or path.find("/bin/external/") != -1
 
 
-refresh_compile_commands = sys.argv[1]
-workspace_dir = os.getenv("BUILD_WORKSPACE_DIRECTORY")
+def main(refresh_compile_commands, workspace_dir):
+    subprocess.call(refresh_compile_commands, shell=True)
 
-subprocess.call(refresh_compile_commands, shell=True)
+    with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_file:
+        compile_commands = json.load(compile_commands_file)
 
-with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_file:
-    compile_commands = json.load(compile_commands_file)
+        for compile_command in compile_commands:
+            args = compile_command["arguments"]
+            for i in range(len(args) - 1):
+                if args[i] == "-iquote" or args[i] == "-I" or args[i] == "-isystem":
+                    if _is_external(args[i + 1]):
+                        args[i] = "-isystem"
+                    else:
+                        args[i] = "-I"
 
-    for compile_command in compile_commands:
-        args = compile_command["arguments"]
-        for i in range(len(args) - 1):
-            if args[i] == "-iquote" or args[i] == "-I" or args[i] == "-isystem":
-                if args[i + 1].startswith("external/") \
-                   or args[i + 1].find("/bin/external/") != -1:
-                    args[i] = "-isystem"
-                else:
-                    args[i] = "-I"
+        compile_commands_file.truncate(0)
+        compile_commands_file.seek(0)
+        json.dump(
+            compile_commands, compile_commands_file, indent=2, check_circular=False
+        )
 
-    compile_commands_file.truncate(0)
-    compile_commands_file.seek(0)
-    json.dump(compile_commands, compile_commands_file, indent=2, check_circular=False)
+
+if __name__ == "__main__":
+    refresh_compile_commands = sys.argv[1]
+    workspace_dir = os.getenv("BUILD_WORKSPACE_DIRECTORY")
+    main(refresh_compile_commands, workspace_dir)

--- a/tools/qac_compile_commands.py
+++ b/tools/qac_compile_commands.py
@@ -1,7 +1,7 @@
 import sys, subprocess, json, os
 
 
-def is_external(path):
+def _is_external(path):
     return path.startswith("external/") or path.find("/bin/external/") != -1
 
 
@@ -15,13 +15,13 @@ with open(workspace_dir + "/compile_commands.json", "r+") as compile_commands_fi
 
     for compile_command in compile_commands:
         args = compile_command["arguments"]
-        for i in range(len(args)):
-            if i + 1 >= len(args):
-                break
-            if (args[i] == "-iquote" or args[i] == "-I") and is_external(args[i + 1]):
-                args[i] = "-isystem"
-            elif (args[i] == "-isystem") and not is_external(args[i + 1]):
-                args[i] = "-I"
+        for i in range(len(args) - 1):
+            if args[i] == "-iquote" or args[i] == "-I" or args[i] == "-isystem":
+                if args[i + 1].startswith("external/") \
+                   or args[i + 1].find("/bin/external/") != -1:
+                    args[i] = "-isystem"
+                else:
+                    args[i] = "-I"
 
     compile_commands_file.truncate(0)
     compile_commands_file.seek(0)

--- a/tools/qac_compile_commands.sh
+++ b/tools/qac_compile_commands.sh
@@ -1,9 +1,0 @@
-#! /bin/bash
-# This script turns the -isystem flag into the -I flag.
-# This is needed for Helix QAC to work properly.
-# Usage: qac_compile_commands <REFRESH_COMPILE_COMMANDS>
-
-REFRESH_COMPILE_COMMANDS=$1
-
-$REFRESH_COMPILE_COMMANDS
-sed -i 's/-isystem/-I/' $BUILD_WORKSPACE_DIRECTORY/compile_commands.json


### PR DESCRIPTION
This PR changes the `qac_compile_commands` script so that it adds `-isystem` before external include paths and `-I` otherwise.
It also adds `get_target_hdrs` aspect.