### PR TITLE
cc: add option to disable tests

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -8,7 +8,21 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
 exports_files(
     glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "cross_compile_build",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_cross_compile_build",
+    flag_values = {":cross_compile_build": "true"},
     visibility = ["//visibility:public"],
 )

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -16,13 +16,13 @@ exports_files(
 )
 
 bool_flag(
-    name = "cross_compile_build",
+    name = "disable_tests",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "_cross_compile_build",
-    flag_values = {":cross_compile_build": "true"},
+    name = "_disable_tests",
+    flag_values = {":disable_tests": "true"},
     visibility = ["//visibility:public"],
 )

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -52,9 +52,8 @@ def _default_features():
     })
 
 def _test_compatible_with():
-    """Disable tests when cross compiling or when building on windows"""
     return select({
-        Label("//cc:_cross_compile_build"): ["@platforms//:incompatible"],
+        Label("//cc:_disable_tests"): ["@platforms//:incompatible"],
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     })

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -43,6 +43,11 @@ def _common_c_opts(nocopts, pedantic = False):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
+def _cross_compile_build():
+    return select({
+        Label("//cc:_cross_compile_build"): ["@platforms//:incompatible"],
+    })
+
 def _default_features():
     return select({
         # treat_warnings_as_errors passes the option -fatal-warnings
@@ -203,6 +208,8 @@ def swift_cc_test_library(**kwargs):
 
     kwargs["tags"] = [TEST_LIBRARY] + kwargs.get("tags", [])
 
+    kwargs["target_compatible_with"] = _cross_compile_build() + kwargs.get("target_compatible_with", [])
+
     native.cc_library(**kwargs)
 
 def swift_cc_test(name, type, **kwargs):
@@ -250,4 +257,5 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)
     kwargs["name"] = name
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
+    kwargs["target_compatible_with"] = _cross_compile_build() + kwargs.get("target_compatible_with", [])
     native.cc_test(**kwargs)


### PR DESCRIPTION
Adds an option to disable building test binaries and test libraries.

This will mostly be activated for our cross compilation builds.

# Testing

- https://github.com/swift-nav/starling/pull/7645