### PR TITLE
cc: add c stubs [BUILD-560]

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -93,6 +93,11 @@ def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility
         visibility = visibility,
     )
 
+def swift_c_library(**kwargs):
+    _ = kwargs.pop("extensions", False)
+    _ = kwargs.pop("standard", [])
+    swift_cc_library(**kwargs)
+
 def swift_cc_library(**kwargs):
     """Wraps cc_library to enforce standards for a production library.
 
@@ -127,6 +132,11 @@ def swift_cc_library(**kwargs):
 
     native.cc_library(**kwargs)
 
+def swift_c_tool_library(**kwargs):
+    _ = kwargs.pop("extensions", False)
+    _ = kwargs.pop("standard", [])
+    swift_cc_tool_library(**kwargs)
+
 def swift_cc_tool_library(**kwargs):
     """Wraps cc_library to enforce standards for a non-production library.
 
@@ -159,6 +169,11 @@ def swift_cc_tool_library(**kwargs):
     kwargs["features"] = _default_features() + kwargs.get("features", [])
 
     native.cc_library(**kwargs)
+
+def swift_c_binary(**kwargs):
+    _ = kwargs.pop("extensions", False)
+    _ = kwargs.pop("standard", [])
+    swift_cc_binary(**kwargs)
 
 def swift_cc_binary(**kwargs):
     """Wraps cc_binary to enforce standards for a production binary.
@@ -193,6 +208,11 @@ def swift_cc_binary(**kwargs):
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
 
     native.cc_binary(**kwargs)
+
+def swift_c_tool(**kwargs):
+    _ = kwargs.pop("extensions", False)
+    _ = kwargs.pop("standard", [])
+    swift_cc_tool(**kwargs)
 
 def swift_cc_tool(**kwargs):
     """Wraps cc_binary to enforce standards for a non-production binary.

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -120,6 +120,7 @@ def swift_cc_library(**kwargs):
     """
     _ = kwargs.pop("exceptions", False)
     _ = kwargs.pop("rtti", False)
+    _ = kwargs.pop("standard", 14)
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
@@ -163,6 +164,7 @@ def swift_cc_tool_library(**kwargs):
     """
     _ = kwargs.pop("exceptions", False)
     _ = kwargs.pop("rtti", False)
+    _ = kwargs.pop("standard", 14)
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
@@ -203,6 +205,7 @@ def swift_cc_binary(**kwargs):
     """
     _ = kwargs.pop("exceptions", False)
     _ = kwargs.pop("rtti", False)
+    _ = kwargs.pop("standard", 14)
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
@@ -246,6 +249,7 @@ def swift_cc_tool(**kwargs):
     """
     _ = kwargs.pop("exceptions", False)
     _ = kwargs.pop("rtti", False)
+    _ = kwargs.pop("standard", 14)
 
     nocopts = kwargs.pop("nocopts", [])
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -118,6 +118,9 @@ def swift_cc_library(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _ = kwargs.pop("exceptions", False)
+    _ = kwargs.pop("rtti", False)
+
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
@@ -158,6 +161,9 @@ def swift_cc_tool_library(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _ = kwargs.pop("exceptions", False)
+    _ = kwargs.pop("rtti", False)
+
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
@@ -195,6 +201,9 @@ def swift_cc_binary(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _ = kwargs.pop("exceptions", False)
+    _ = kwargs.pop("rtti", False)
+
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
@@ -235,6 +244,9 @@ def swift_cc_tool(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _ = kwargs.pop("exceptions", False)
+    _ = kwargs.pop("rtti", False)
+
     nocopts = kwargs.pop("nocopts", [])
 
     copts = _common_c_opts(nocopts, pedantic = False)


### PR DESCRIPTION
Adds stubs for new c only macros.

These stubs need to be introduced to the codebase before the implementations
can be merged otherwise it will cause build failures.