### PR TITLE
third_party: rapidcheck: add flag to disable rtti

### DIFF
--- a/third_party/rapidcheck.BUILD
+++ b/third_party/rapidcheck.BUILD
@@ -8,14 +8,32 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
 package(
     default_visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "disable_rtti",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_disable_rtti",
+    flag_values = {":disable_rtti": "true"},
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "rapidcheck",
     srcs = glob(["src/**"]),
     hdrs = glob(["include/**"] + ["extras/**"]),
+    defines = select({
+        ":_disable_rtti": ["RC_DONT_USE_RTTI"],
+        "//conditions:default": [],
+    }),
     includes = [
         "extras/gtest/include",
         "include",


### PR DESCRIPTION
Adds an option to disable RTTI in rapidcheck.

We disable this option in the CMake build here: https://github.com/swift-nav/cmake/blob/6376d60940d252b7e303bf01486e88d839bb03b5/FindRapidCheck.cmake#L17.

It is required for some of our code to build correctly.