### PR TITLE
Use clang tidy from llvm distribution for Linux [BUILD-592]

### DIFF
--- a/clang_tidy/BUILD
+++ b/clang_tidy/BUILD
@@ -25,7 +25,12 @@ label_flag(
 
 filegroup(
     name = "clang_tidy_executable_default",
-    srcs = [":clang_tidy_bin"],
+    srcs = select(
+        {
+            "@platforms//os:linux": ["@llvm-distribution//:clang-tidy"],
+            "//conditions:default": [":clang_tidy_bin"],
+        },
+    ),
 )
 
 label_flag(


### PR DESCRIPTION
This PR allows you to use `clang-tidy` from the llvm distribution when Linux is used and system `clang-tidy` for the other systems.