### PR TITLE
libsbp issues with redhat products

### DIFF
--- a/third_party/check.BUILD
+++ b/third_party/check.BUILD
@@ -19,6 +19,7 @@ cmake(
     name = "check",
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
+        "CMAKE_INSTALL_LIBDIR": "lib",
     },
     lib_source = ":srcs",
     linkopts = select({

--- a/third_party/nlopt.BUILD
+++ b/third_party/nlopt.BUILD
@@ -23,6 +23,7 @@ cmake(
     name = "nlopt",
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
+        "CMAKE_INSTALL_LIBDIR": "lib",
     },
     generate_args = [
         "-DBUILD_SHARED_LIBS=OFF",


### PR DESCRIPTION
## Issue

If you were to clone [libsbp](https://github.com/swift-nav/libsbp) and compile it using Bazel using a Linux distro (like Redhat) where the cmake [GNU library path](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) is defined as `lib64`, it will error out with this message:

```
INFO: Analyzed 13 targets (0 packages loaded, 0 targets configured).
INFO: Found 13 targets...
ERROR: /home/rodrigor/.cache/bazel/_bazel_rodrigor/d7e5ed2e8b08c45b2d2fdd32997ee05d/external/check/BUILD.bazel:18:6: output 'external/check/check/lib/libcheck.a' was not created
ERROR: /home/rodrigor/.cache/bazel/_bazel_rodrigor/d7e5ed2e8b08c45b2d2fdd32997ee05d/external/check/BUILD.bazel:18:6: Foreign Cc - CMake: Building check failed: not all outputs were created or valid
INFO: Elapsed time: 12.029s, Critical Path: 11.86s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
FAILED: Build did NOT complete successfully
```

You can trial it your self by running the following commands inside you libsbp code base (if you use `docker` rather than `podman`, just swap the two around, it hopefully should work):

```
podman pull redhat/ubi9
podman run -it --rm -v "${PWD}:/mnt/workspace" -w '/mnt/workspace' --privileged redhat/ubi9

dnf install -y --allowerasing cmake gcc g++ curl
curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64"
mv bazelisk-linux-amd64 /usr/local/bin/bazel
chmod u+x /usr/local/bin/bazel
bazel build //...
```

The issue is that the `cmake(...)` rule expects the `out_static_libs` file to exist under the `/usr/local/lib` directory rather then `/usr/local/lib64` directory under the install directory. To fix this I've explicitly set the desired library folder.

For reference, this issue was raised with the zstd library as well - https://github.com/envoyproxy/envoy/issues/20923.