### PR TITLE
check: disable subunit

### DIFF
--- a/third_party/check.BUILD
+++ b/third_party/check.BUILD
@@ -20,6 +20,7 @@ cmake(
     cache_entries = {
         "CMAKE_C_FLAGS": "-fPIC",
         "CMAKE_INSTALL_LIBDIR": "lib",
+        "HAVE_SUBUNIT": "0",
     },
     lib_source = ":srcs",
     linkopts = select({


### PR DESCRIPTION
This was triggering on my machine for some reason (maybe I have subunit
installed?) and caused a linker error:

	ld.lld: error: undefined symbol: subunit_test_pass
	>>> referenced by check_log.c
	>>>               check_log.c.o:(subunit_lfun) in archive bazel-out/k8-fastbuild/bin/external/check/check/lib/libcheck.a

	ld.lld: error: undefined symbol: subunit_test_start
	>>> referenced by check_log.c
	>>>               check_log.c.o:(subunit_lfun) in archive bazel-out/k8-fastbuild/bin/external/check/check/lib/libcheck.a

	ld.lld: error: undefined symbol: subunit_test_error
	>>> referenced by check_log.c
	>>>               check_log.c.o:(subunit_lfun) in archive bazel-out/k8-fastbuild/bin/external/check/check/lib/libcheck.a

	ld.lld: error: undefined symbol: subunit_test_fail
	>>> referenced by check_log.c
	>>>               check_log.c.o:(subunit_lfun) in archive bazel-out/k8-fastbuild/bin/external/check/check/lib/libcheck.a
	clang: error: linker command failed with exit code 1 (use -v to see invocation)

We don't use subunit... so should be safe to disable it.
