### PR TITLE
Add check_attributes aspect [BUILD-638]

### DIFF
--- a/check_attributes/BUILD.bazel
+++ b/check_attributes/BUILD.bazel
@@ -1,0 +1,9 @@
+filegroup(
+    name = "excluded_default",
+)
+
+label_flag(
+    name = "excluded",
+    build_setting_default = ":excluded_default",
+    visibility = ["//visibility:public"],
+)

--- a/check_attributes/check_attributes.bzl
+++ b/check_attributes/check_attributes.bzl
@@ -1,43 +1,32 @@
-def _run_check_attributes(ctx, infile, discriminator):
-    outfile = ctx.actions.declare_file(
-        "bazel_check_attribute_" + infile.path + "." + discriminator + ".txt",
-    )
+load("//tools:get_cc_files.bzl", "get_cc_files")
+
+def _run_check_attributes(ctx, infile):
+    output = ctx.actions.declare_file(infile.path + ".check-attributes.txt")
 
     ctx.actions.run_shell(
         inputs = [infile],
-        outputs = [outfile],
+        outputs = [output],
         command = """
             result=0
 
             matches=$(grep -Hn __attribute__ "{infile}")
 
-            touch {outfile}
+            touch {output}
 
             if [ -n "$matches" ];
             then
                 while read -r line;
                 do
-                    echo "error: Do not use __attribute__, prefer one of the macros from swiftnav/macros.h" | tee {outfile}
-                    echo "$line" | tee {outfile}
+                    echo "error: Do not use __attribute__, prefer one of the macros from swiftnav/macros.h" | tee {output}
+                    echo "$line" | tee {output}
                     result=1
                 done <<< $matches
             fi
 
             exit $result
-        """.format(infile = infile.path, outfile = outfile.path),
+        """.format(infile = infile.path, output = output.path),
     )
-    return outfile
-
-def _rule_files(ctx):
-    files = []
-    if hasattr(ctx.rule.attr, "srcs"):
-        for src in ctx.rule.attr.srcs:
-            files += [src for src in src.files.to_list() if src.is_source]
-
-    if hasattr(ctx.rule.attr, "hdrs"):
-        for hdr in ctx.rule.attr.hdrs:
-            files += [hdr for hdr in hdr.files.to_list() if hdr.is_source]
-    return files
+    return output
 
 def _check_attributes_impl(target, ctx):
     # if not a C/C++ target, we are not interested
@@ -46,10 +35,10 @@ def _check_attributes_impl(target, ctx):
 
     outputs = []
 
-    for file in _rule_files(ctx):
+    for file in get_cc_files(ctx):
         if file in ctx.files._excluded:
             continue
-        outputs.append(_run_check_attributes(ctx, file, target.label.name))
+        outputs.append(_run_check_attributes(ctx, file))
 
     return [
         OutputGroupInfo(report = depset(direct = outputs)),

--- a/check_attributes/check_attributes.bzl
+++ b/check_attributes/check_attributes.bzl
@@ -1,0 +1,65 @@
+def _run_check_attributes(ctx, infile, discriminator):
+    outfile = ctx.actions.declare_file(
+        "bazel_check_attribute_" + infile.path + "." + discriminator + ".txt",
+    )
+
+    ctx.actions.run_shell(
+        inputs = [infile],
+        outputs = [outfile],
+        command = """
+            result=0
+
+            matches=$(grep -Hn __attribute__ "{infile}")
+
+            touch {outfile}
+
+            if [ -n "$matches" ];
+            then
+                while read -r line;
+                do
+                    echo "error: Do not use __attribute__, prefer one of the macros from swiftnav/macros.h" | tee {outfile}
+                    echo "$line" | tee {outfile}
+                    result=1
+                done <<< $matches
+            fi
+
+            exit $result
+        """.format(infile = infile.path, outfile = outfile.path),
+    )
+    return outfile
+
+def _rule_files(ctx):
+    files = []
+    if hasattr(ctx.rule.attr, "srcs"):
+        for src in ctx.rule.attr.srcs:
+            files += [src for src in src.files.to_list() if src.is_source]
+
+    if hasattr(ctx.rule.attr, "hdrs"):
+        for hdr in ctx.rule.attr.hdrs:
+            files += [hdr for hdr in hdr.files.to_list() if hdr.is_source]
+    return files
+
+def _check_attributes_impl(target, ctx):
+    # if not a C/C++ target, we are not interested
+    if not CcInfo in target:
+        return []
+
+    outputs = []
+
+    for file in _rule_files(ctx):
+        if file in ctx.files._excluded:
+            continue
+        outputs.append(_run_check_attributes(ctx, file, target.label.name))
+
+    return [
+        OutputGroupInfo(report = depset(direct = outputs)),
+    ]
+
+check_attributes = aspect(
+    implementation = _check_attributes_impl,
+    fragments = ["cpp"],
+    attrs = {
+        "_excluded": attr.label(default = Label("//check_attributes:excluded")),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,3 +1,5 @@
+load("//tools:get_cc_files.bzl", "get_cc_files")
+
 def _check_format(ctx, exe, config, infile, clang_format_bin):
     output = ctx.actions.declare_file(infile.path + ".clang-format.txt")
 
@@ -19,18 +21,6 @@ def _check_format(ctx, exe, config, infile, clang_format_bin):
     )
     return output
 
-def _extract_files(ctx):
-    files = []
-    if hasattr(ctx.rule.attr, "srcs"):
-        for src in ctx.rule.attr.srcs:
-            files += [src for src in src.files.to_list() if src.is_source]
-
-    if hasattr(ctx.rule.attr, "hdrs"):
-        for hdr in ctx.rule.attr.hdrs:
-            files += [hdr for hdr in hdr.files.to_list() if hdr.is_source]
-
-    return files
-
 def _clang_format_check_aspect_impl(target, ctx):
     # if not a C/C++ target, we are not interested
     if not CcInfo in target:
@@ -39,7 +29,7 @@ def _clang_format_check_aspect_impl(target, ctx):
     exe = ctx.attr._clang_format.files_to_run
     config = ctx.attr._clang_format_config.files.to_list()[0]
     clang_format_bin = ctx.attr._clang_format_bin.files.to_list()[0]
-    files = _extract_files(ctx)
+    files = get_cc_files(ctx)
 
     outputs = []
     for file in files:

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//cc:defs.bzl", "BINARY", "LIBRARY")
+load("//tools:get_cc_files.bzl", "get_cc_srcs")
 
 def _flatten(input_list):
     return [item for sublist in input_list for item in sublist]
@@ -71,13 +72,6 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
     )
     return outfile
 
-def _rule_sources(ctx):
-    srcs = []
-    if hasattr(ctx.rule.attr, "srcs"):
-        for src in ctx.rule.attr.srcs:
-            srcs += [src for src in src.files.to_list() if src.is_source]
-    return srcs
-
 def _toolchain_flags(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
     feature_configuration = cc_common.configure_features(
@@ -142,7 +136,7 @@ def _clang_tidy_aspect_impl(target, ctx):
     final_flags = _replace_gendir(safe_flags, ctx)
     compilation_contexts = _get_compilation_contexts(target, ctx)
 
-    srcs = _rule_sources(ctx)
+    srcs = get_cc_srcs(ctx)
 
     # We exclude headers because we shouldn't run clang-tidy directly with them.
     # Headers will be linted if included in a source file.


### PR DESCRIPTION
This PR adds the `check_attributes` aspect. It checks whether `__attributes__` is used in any file of a target.