### PR TITLE
Fix plantUML call in doxygen [BUILD-450]

### DIFF
--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -37,7 +37,7 @@ def _swift_doxygen_impl(ctx):
         sed -i "s|@DOXYGEN_DOT_PATH@|$DOXYGEN_DOT_PATH|g" {config}
         sed -i "s|@PLANTUML_JAR_PATH@|/usr/local/bin/plantuml.jar|g" {config}
 
-        doxygen {config}
+        PATH=$PATH doxygen {config}
         """.format(config = config.path),
     )
 


### PR DESCRIPTION
I don't know why, but doxygen has a problem finding Java when run by bazel on CI. I encountered a similar problem in the past and was able to fix it by passing the `PATH` env var. Here it also did the trick.

Tested here:
https://github.com/swift-nav/starling/pull/7780

Wrong log `(sh: 1: java: not found)`:
https://jenkins.ci.swift-nav.com/blue/rest/organizations/jenkins/pipelines/swift-nav/pipelines/starling/branches/PR-7780/runs/13/nodes/276/log/?start=0

Correct log:
https://jenkins.ci.swift-nav.com/blue/rest/organizations/jenkins/pipelines/swift-nav/pipelines/starling/branches/PR-7780/runs/17/nodes/57/log/?start=0
