### PR TITLE
clang-tidy: Use correct compilation flags when compiling C

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -159,7 +159,6 @@ def _clang_tidy_aspect_impl(target, ctx):
     rule_flags = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
     safe_flags = _safe_flags(toolchain_flags + rule_flags)
     final_flags = _replace_gendir(safe_flags, ctx)
-
     compilation_contexts = _get_compilation_contexts(target, ctx)
 
     # We exclude headers because we shouldn't run clang-tidy directly with them.


### PR DESCRIPTION
This PR fixes the problem of analyzing C source files using `clang-tidy`. The problem was that we passed C++ flags even when compiling C source files. Clang-tidy complained about `-stdlib=libc++`.
In order to fix this, I introduced a statement that checks if the extension of the file is "c" and gets the correct compilation flags.

This issue appeared because in PR https://github.com/swift-nav/rules_swiftnav/pull/67 we enabled `-Werror` by default.

# Testing
https://github.com/swift-nav/starling/pull/7851
https://jenkins.ci.swift-nav.com/blue/organizations/jenkins/swift-nav%2Fstarling/detail/PR-7851/1/pipeline
