### PR TITLE
Enable stamping static libraries [BUILD-650]

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -36,6 +36,8 @@ TEST = "test"
 # Name for test sources
 TEST_SRCS = "test_srcs"
 
+STAMP_RAW_LIB_SUFIX = "_raw"
+
 # Form the c standard string
 def _c_standard(extensions = False, standard = 99):
     extensions = "gnu" if extensions else "c"
@@ -124,6 +126,12 @@ def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility
     stamp_file(name = source_name, out = out, defaults = defaults, template = template)
 
     swift_cc_library(
+        name = name + STAMP_RAW_LIB_SUFIX,
+        srcs = [source_name],
+        visibility = visibility,
+    )
+
+    swift_cc_library(
         name = name,
         hdrs = hdrs,
         includes = includes,
@@ -131,10 +139,15 @@ def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility
         visibility = visibility,
     )
 
-def cc_static_library(name, deps, visibility = ["//visibility:private"]):
+def cc_static_library(name, deps, stamp_libs = [], visibility = ["//visibility:private"]):
+    stamp_raw_libs = []
+
+    for lib in stamp_libs:
+        stamp_raw_libs.append(lib + STAMP_RAW_LIB_SUFIX)
+
     _cc_static_library(
         name = name,
-        deps = deps,
+        deps = deps + stamp_raw_libs,
         target_compatible_with = select({
             # Creating static libraries is not supported by macos yet.
             "@platforms//os:macos": ["@platforms//:incompatible"],

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -36,7 +36,7 @@ TEST = "test"
 # Name for test sources
 TEST_SRCS = "test_srcs"
 
-STAMPED_LIB_SUFIX = ".stamped"
+STAMPED_LIB_SUFFIX = ".stamped"
 
 # Form the c standard string
 def _c_standard(extensions = False, standard = 99):

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -132,7 +132,7 @@ def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility
 
     # This variant has the stamped symbols in the archive
     swift_cc_library(
-        name = name + STAMPED_LIB_SUFIX,
+        name = name + STAMPED_LIB_SUFFIX,
         srcs = [source_name],
         visibility = visibility,
     )


### PR DESCRIPTION
Our static libraries also needs the stamping feature. This simple change enables stamping in static libraries.

Example usage:
```
cc_static_library(
    name = "foo_archive",
    stamp_libs = [
        "//foo:version",
        "//bar:version",
    ],
    visibility = ["//visibility:public"],
    deps = [
        ":foo",
    ],
)
```

# Testing
https://github.com/swift-nav/starling/pull/7826