### PR TITLE
Add get_cc_test_srcs aspect and compare_test_srcs script [BUILD-657]

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -570,6 +570,7 @@ def swift_cc_test(name, type, **kwargs):
         srcs = srcs,
         visibility = ["//visibility:public"],
         tags = [TEST_SRCS],
+        target_compatible_with = kwargs.get("target_compatible_with", []),
     )
 
     kwargs["srcs"] = [":" + srcs_name]

--- a/cc_files/BUILD.bazel
+++ b/cc_files/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
+load("//tools:string_list_file.bzl", "string_list_file")
+
+sh_binary(
+    name = "get_test_cc_files",
+    srcs = ["get_test_cc_files.sh"],
+    visibility = ["//visibility:public"],
+)
+
+string_list_flag(
+    name = "ignored_test_srcs",
+    build_setting_default = [],
+)
+
+string_list_file(
+    name = "_ignored_test_srcs",
+    string_list = ":ignored_test_srcs",
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "compare_cc_test_files",
+    srcs = ["compare_cc_test_files.sh"],
+    args = [
+        "$(location :_ignored_test_srcs)",
+    ],
+    data = [
+        ":_ignored_test_srcs",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/cc_files/compare_cc_test_files.sh
+++ b/cc_files/compare_cc_test_files.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This script compares the bazel_test_srcs.txt and
+# build/cmake_test_srcs.txt files which contain Bazel and CMake test
+# source files, respectively.
+# Usage: compare_test_srcs <IGNORED_FILES>
+
+ignored_files=$(cat $1)
+
+cd $BUILD_WORKSPACE_DIRECTORY
+
+if [ ! -f bazel_test_srcs.txt ]; then
+    echo "bazel_test_srcs.txt file not found"
+    exit 1
+fi
+
+if [ ! -f build/cmake_test_srcs.txt ]; then
+    echo "build/cmake_test_srcs.txt file not found"
+    exit 1
+fi
+
+flags=""
+
+for f in $ignored_files
+do
+    flags="$flags -I ^$f$"
+done
+
+if ! results=$(diff $flags bazel_test_srcs.txt build/cmake_test_srcs.txt); then
+    for result in "$results"
+    do
+        i=0
+        for el in $result
+        do
+            if [[ $i -eq 1 ]]; then
+                if [[ "$el" == ">" ]]; then
+                    echo -n "Bazel doesn't have: "
+                else
+                    echo -n "CMake doesn't have: "
+                fi
+            elif [[ $i -eq 2 ]]; then
+                echo $el
+            fi
+            i=$((i+1))
+        done
+    done
+fi

--- a/cc_files/compare_cc_test_files.sh
+++ b/cc_files/compare_cc_test_files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script compares the bazel_test_srcs.txt and
-# build/cmake_test_srcs.txt files which contain Bazel and CMake test
+# build/cmake_test_srcs.txt files, which contain Bazel and CMake test
 # source files, respectively.
 # Usage: compare_test_srcs <IGNORED_FILES>
 
@@ -44,4 +44,5 @@ if ! results=$(diff $flags bazel_test_srcs.txt build/cmake_test_srcs.txt); then
             i=$((i+1))
         done
     done
+    exit 1
 fi

--- a/cc_files/compare_cc_test_files.sh
+++ b/cc_files/compare_cc_test_files.sh
@@ -27,22 +27,19 @@ do
 done
 
 if ! results=$(diff $flags bazel_test_srcs.txt build/cmake_test_srcs.txt); then
-    for result in "$results"
+    i=0
+    for result in $results
     do
-        i=0
-        for el in $result
-        do
-            if [[ $i -eq 1 ]]; then
-                if [[ "$el" == ">" ]]; then
-                    echo -n "Bazel doesn't have: "
-                else
-                    echo -n "CMake doesn't have: "
-                fi
-            elif [[ $i -eq 2 ]]; then
-                echo $el
+        if [[ $(( i % 3 )) == 1 ]]; then
+            if [[ "$result" == ">" ]]; then
+                echo -n "Bazel doesn't have: "
+            else
+                echo -n "CMake doesn't have: "
             fi
-            i=$((i+1))
-        done
+        elif [[ $(( i % 3 )) == 2 ]]; then
+            echo $result
+        fi
+        i=$((i+1))
     done
     exit 1
 fi

--- a/cc_files/get_cc_files.bzl
+++ b/cc_files/get_cc_files.bzl
@@ -68,6 +68,7 @@ def _get_cc_test_srcs_impl(target, ctx):
         inputs = [],
         outputs = [output],
         command = """
+            touch {output}
             for s in {srcs}
             do
                 echo $s >> {output}

--- a/cc_files/get_cc_files.bzl
+++ b/cc_files/get_cc_files.bzl
@@ -1,4 +1,4 @@
-load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY")
+load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY", "TEST_SRCS")
 
 FilesInfo = provider(
     fields = {
@@ -54,4 +54,29 @@ def _get_cc_target_hdrs_impl(target, ctx):
 
 get_cc_target_hdrs = aspect(
     implementation = _get_cc_target_hdrs_impl,
+)
+
+def _get_cc_test_srcs_impl(target, ctx):
+    tags = getattr(ctx.rule.attr, "tags", [])
+    if not TEST_SRCS in tags:
+        return [OutputGroupInfo(report = [])]
+
+    output = ctx.actions.declare_file(ctx.rule.attr.name + "_test_srcs.txt")
+    srcs = " ".join([f.path for f in get_cc_srcs(ctx) if f.extension != "h" and f.extension != "hpp"])
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [output],
+        command = """
+            for s in {srcs}
+            do
+                echo $s >> {output}
+            done
+        """.format(output = output.path, srcs = srcs),
+    )
+
+    return [OutputGroupInfo(report = depset(direct = [output]))]
+
+get_cc_test_srcs = aspect(
+    implementation = _get_cc_test_srcs_impl,
 )

--- a/cc_files/get_test_cc_files.sh
+++ b/cc_files/get_test_cc_files.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd $BUILD_WORKSPACE_DIRECTORY
+
+bazel build --aspects @rules_swiftnav//cc_files:get_cc_files.bzl%get_cc_test_srcs --output_groups=report //...
+find ./bazel-out/ -type f -regex ".*_test_srcs\.txt" -exec cat {} + | sort > bazel_test_srcs.txt
+
+echo "Test sources are stored in the $PWD/bazel_test_srcs.txt file"

--- a/check_attributes/check_attributes.bzl
+++ b/check_attributes/check_attributes.bzl
@@ -1,4 +1,4 @@
-load("//tools:get_cc_files.bzl", "get_cc_files")
+load("//cc_files:get_cc_files.bzl", "get_cc_files")
 
 def _run_check_attributes(ctx, infile):
     output = ctx.actions.declare_file(infile.path + ".check-attributes.txt")

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,4 +1,4 @@
-load("//tools:get_cc_files.bzl", "get_cc_files")
+load("//cc_files:get_cc_files.bzl", "get_cc_files")
 
 def _check_format(ctx, exe, config, infile, clang_format_bin):
     output = ctx.actions.declare_file(infile.path + ".clang-format.txt")

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//cc:defs.bzl", "BINARY", "LIBRARY")
-load("//tools:get_cc_files.bzl", "get_cc_srcs")
+load("//cc_files:get_cc_files.bzl", "get_cc_srcs")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 def _flatten(input_list):

--- a/tools/gen_sonar_cfg.bzl
+++ b/tools/gen_sonar_cfg.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("//tools:get_cc_files.bzl", "FilesInfo", "get_cc_target_files")
+load("//cc_files:get_cc_files.bzl", "FilesInfo", "get_cc_target_files")
 
 def _gen_sonar_cfg_impl(ctx):
     all_files_bash = ""

--- a/tools/string_list_file.bzl
+++ b/tools/string_list_file.bzl
@@ -1,0 +1,27 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _string_list_file(ctx):
+    out = ctx.actions.declare_file(ctx.attr.name + ".txt")
+
+    ctx.actions.run_shell(
+        outputs = [out],
+        command = """
+        touch {out}
+        for s in {string_list}
+        do
+            echo $s >> {out}
+        done
+        """.format(
+            out = out.path,
+            string_list = " ".join(ctx.attr.string_list[BuildSettingInfo].value),
+        ),
+    )
+
+    return [DefaultInfo(files = depset([out]))]
+
+string_list_file = rule(
+    implementation = _string_list_file,
+    attrs = {
+        "string_list": attr.label(mandatory = True),
+    },
+)


### PR DESCRIPTION
This PR adds:
- the `get_cc_test_srcs` aspect, which walks through test source files (distinguishes them by the [TEST_SRC](https://github.com/swift-nav/rules_swiftnav/blob/main/cc/defs.bzl#L37) tag) and stores them in files,
- the `get_test_cc_files` script, which uses `get_cc_test_srcs` and creates the `bazel_test_srcs.txt` file with all test sources,
- the `compare_cc_test_files` script, which compares the `bazel_test_srcs.txt` and `build/cmake_test_srcs.txt` files.

# Testing 

https://github.com/swift-nav/starling/pull/7881