### PR TITLE
cc: toolchain: add rust compatible musl toolchains [BUILD-529]

### DIFF
--- a/cc/constraints/BUILD.bazel
+++ b/cc/constraints/BUILD.bazel
@@ -4,6 +4,8 @@ package(default_visibility = ["//visibility:public"])
 
 constraint_setting(name = "compiler")
 
+contraint_setting(name = "libc")
+
 constraint_setting(name = "toolchain")
 
 constraint_value(
@@ -14,6 +16,11 @@ constraint_value(
 constraint_value(
     name = "gcc-6",
     constraint_setting = ":compiler",
+)
+
+constraint_value(
+    name = "musl",
+    constraint_setting = ":libc",
 )
 
 constraint_value(

--- a/cc/constraints/BUILD.bazel
+++ b/cc/constraints/BUILD.bazel
@@ -4,7 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 constraint_setting(name = "compiler")
 
-contraint_setting(name = "libc")
+constraint_setting(name = "libc")
 
 constraint_setting(name = "toolchain")
 

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -76,4 +76,3 @@ def arm_linux_musleabihf_toolchain():
 
 def register_arm_linux_musleabihf_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
-

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -17,13 +17,13 @@ X86_64_DARWIN_LLVM = "https://github.com/llvm/llvm-project/releases/download/llv
 
 X86_64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
 
+AARCH64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-cross-11.2.0/aarch64-linux-musl-cross.tar.gz"
+
+ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-cross-11.2.0/arm-linux-musleabihf-cross.tar.gz"
+
+X86_64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-cross-11.2.0/x86_64-linux-musl-cross.tar.gz"
+
 GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
-
-ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/arm-linux-musleabihf.tar.gz"
-
-X86_64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/x86_64-linux-musl.tar.gz"
-
-AARCH64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/aarch64-linux-musl.tar.gz"
 
 def swift_cc_toolchain():
     maybe(
@@ -58,6 +58,42 @@ def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux")
 
+def aarch64_linux_musl_toolchain():
+    http_archive(
+        name = "aarch64-linux-musl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/aarch64:musl.BUILD.bzl",
+        sha256 = "a6650541dcc778b79add1dd7369869d5d38ddefa9362b7e32d4cc1267fa7977e",
+        strip_prefix = "output",
+        url = AARCH64_LINUX_MUSL,
+    )
+
+def register_aarch64_linux_musl_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/aarch64:toolchain")
+
+def arm_linux_musleabihf_toolchain():
+    http_archive(
+        name = "arm-linux-musleabihf",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/armhf:musl.BUILD.bzl",
+        sha256 = "7b310a8bf70500a4072f87c3292321fc4f7b91cc67a85a31e7cf13508fa24a3c",
+        strip_prefix = "output",
+        url = ARM_LINUX_MUSLEABIHF,
+    )
+
+def register_arm_linux_musleabihf_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
+
+def x86_64_linux_musl_toolchain():
+    http_archive(
+        name = "x86_64-linux-musl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/x86_64:musl.BUILD.bzl",
+        sha256 = "594395e60bc93acd7eb049f6d8c28a9c5ad5b6060b230e94f19cd8c005cd3a91",
+        strip_prefix = "output",
+        url = X86_64_LINUX_MUSL,
+    )
+
+def register_x86_64_linux_musl_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/x86_64:toolchain")
+
 def gcc_arm_embedded_toolchain():
     http_archive(
         name = "gcc_arm_embedded_toolchain",
@@ -70,35 +106,3 @@ def gcc_arm_embedded_toolchain():
 def register_gcc_arm_embedded_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain")
 
-def arm_linux_musleabihf_toolchain():
-    http_archive(
-        name = "arm-linux-musleabihf",
-        build_file = "@rules_swiftnav//cc/toolchains/musl/armhf:musl.BUILD.bzl",
-        strip_prefix = "output",
-        url = ARM_LINUX_MUSLEABIHF,
-    )
-
-def register_arm_linux_musleabihf_toolchain():
-    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
-
-def x86_64_linux_musl_toolchain():
-    http_archive(
-        name = "x86_64-linux-musl",
-        build_file = "@rules_swiftnav//cc/toolchains/musl/x86_64:musl.BUILD.bzl",
-        strip_prefix = "output",
-        url = X86_64_LINUX_MUSL,
-    )
-
-def register_x86_64_linux_musl_toolchain():
-    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/x86_64:toolchain")
-
-def aarch64_linux_musl_toolchain():
-    http_archive(
-        name = "aarch64-linux-musl",
-        build_file = "@rules_swiftnav//cc/toolchains/musl/aarch64:musl.BUILD.bzl",
-        strip_prefix = "output",
-        url = AARCH64_LINUX_MUSL,
-    )
-
-def register_aarch64_linux_musl_toolchain():
-    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/aarch64:toolchain")

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -19,6 +19,8 @@ X86_64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvm
 
 GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
 
+ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl/arm-linux-musleabihf-cross.tar.gz"
+
 def swift_cc_toolchain():
     maybe(
         http_archive,
@@ -63,3 +65,15 @@ def gcc_arm_embedded_toolchain():
 
 def register_gcc_arm_embedded_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain")
+
+def arm_linux_musleabihf_toolchain():
+    http_archive(
+        name = "arm-linux-musleabihf",
+        build_file = "@rules_swiftnav//cc/toolchains/musl.BUILD.bzl",
+        strip_prefix = "output",
+        url = ARM_LINUX_MUSLEABIHF,
+    )
+
+def register_arm_linux_musleahihf_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
+

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -19,7 +19,11 @@ X86_64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvm
 
 GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
 
-ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-beta/arm-linux-musleabihf-cross.tar.gz"
+ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/arm-linux-musleabihf.tar.gz"
+
+X86_64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/x86_64-linux-musl.tar.gz"
+
+AARCH64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-test-2/aarch64-linux-musl.tar.gz"
 
 def swift_cc_toolchain():
     maybe(
@@ -69,10 +73,32 @@ def register_gcc_arm_embedded_toolchain():
 def arm_linux_musleabihf_toolchain():
     http_archive(
         name = "arm-linux-musleabihf",
-        build_file = "@rules_swiftnav//cc/toolchains/musl:musl.BUILD.bzl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/armhf:musl.BUILD.bzl",
         strip_prefix = "output",
         url = ARM_LINUX_MUSLEABIHF,
     )
 
 def register_arm_linux_musleabihf_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
+
+def x86_64_linux_musl_toolchain():
+    http_archive(
+        name = "x86_64-linux-musl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/x86_64:musl.BUILD.bzl",
+        strip_prefix = "output",
+        url = X86_64_LINUX_MUSL,
+    )
+
+def register_x86_64_linux_musl_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/x86_64:toolchain")
+
+def aarch64_linux_musl_toolchain():
+    http_archive(
+        name = "aarch64-linux-musl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl/aarch64:musl.BUILD.bzl",
+        strip_prefix = "output",
+        url = AARCH64_LINUX_MUSL,
+    )
+
+def register_aarch64_linux_musl_toolchain():
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/aarch64:toolchain")

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -19,7 +19,7 @@ X86_64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvm
 
 GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
 
-ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl/arm-linux-musleabihf-cross.tar.gz"
+ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-beta/arm-linux-musleabihf-cross.tar.gz"
 
 def swift_cc_toolchain():
     maybe(
@@ -69,11 +69,11 @@ def register_gcc_arm_embedded_toolchain():
 def arm_linux_musleabihf_toolchain():
     http_archive(
         name = "arm-linux-musleabihf",
-        build_file = "@rules_swiftnav//cc/toolchains/musl.BUILD.bzl",
+        build_file = "@rules_swiftnav//cc/toolchains/musl:musl.BUILD.bzl",
         strip_prefix = "output",
         url = ARM_LINUX_MUSLEABIHF,
     )
 
-def register_arm_linux_musleahihf_toolchain():
+def register_arm_linux_musleabihf_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/musl/armhf:toolchain")
 

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -105,4 +105,3 @@ def gcc_arm_embedded_toolchain():
 
 def register_gcc_arm_embedded_toolchain():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain")
-

--- a/cc/strip.bzl
+++ b/cc/strip.bzl
@@ -1,0 +1,39 @@
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+
+def _strip_impl(ctx):
+    binary = ctx.file.binary
+    out = ctx.actions.declare_file(ctx.attr.name)
+    cc_toolchain = find_cpp_toolchain(ctx)
+    strip = cc_toolchain.strip_executable
+
+    args = ctx.actions.args()
+    args.add("-S")
+    args.add("-p")
+    args.add("-o")
+    args.add(out)
+    args.add(binary)
+    [args.add(opt) for opt in ctx.attr.stripopts]
+
+    ctx.actions.run(
+        outputs = [out],
+        inputs = [binary] + cc_toolchain.all_files.to_list(),
+        executable = strip,
+        arguments = [args],
+        mnemonic = "Strip",
+        progress_message = "Stripping {}".format(binary.basename),
+    )
+
+    return DefaultInfo(executable = out)
+
+strip = rule(
+    implementation = _strip_impl,
+    attrs = {
+        "binary": attr.label(allow_single_file = True),
+        "stripopts": attr.string_list(),
+        "_cc_toolchain": attr.label(
+            default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+        ),
+    },
+    executable = True,
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+)

--- a/cc/toolchains/musl/aarch64/BUILD.bazel
+++ b/cc/toolchains/musl/aarch64/BUILD.bazel
@@ -1,0 +1,111 @@
+load(":config.bzl", "config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:ar",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "as_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:as",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:bin",
+        "@aarch64-linux-musl//:include",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:ar",
+        "@aarch64-linux-musl//:gcc",
+        "@aarch64-linux-musl//:ld",
+        "@aarch64-linux-musl//:lib",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:objcopy",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-musl//:strip",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":compiler_files",
+        ":linker_files",
+        "@aarch64-linux-musl//:bin",
+    ],
+    tags = ["manual"],
+)
+
+config(name = "config")
+
+cc_toolchain(
+    name = "cc_toolchain",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    as_files = ":as_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+    tags = ["manual"],
+    toolchain_config = ":config",
+    toolchain_identifier = "aarch64-linux-musl",
+)
+
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        "//cc/constraints:musl",
+    ],
+    toolchain = ":cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/cc/toolchains/musl/aarch64/config.bzl
+++ b/cc/toolchains/musl/aarch64/config.bzl
@@ -1,0 +1,139 @@
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+SDK_PATH_PREFIX = "wrappers/aarch64-linux-musl-{}"
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "ar",
+            path = SDK_PATH_PREFIX.format("ar"),
+        ),
+        tool_path(
+            name = "as",
+            path = SDK_PATH_PREFIX.format("as"),
+        ),
+        tool_path(
+            name = "cpp",
+            path = SDK_PATH_PREFIX.format("cpp"),
+        ),
+        tool_path(
+            name = "gcc",
+            path = SDK_PATH_PREFIX.format("gcc"),
+        ),
+        tool_path(
+            name = "g++",
+            path = SDK_PATH_PREFIX.format("g++"),
+        ),
+        tool_path(
+            name = "gcov",
+            path = SDK_PATH_PREFIX.format("gcov"),
+        ),
+        tool_path(
+            name = "ld",
+            path = SDK_PATH_PREFIX.format("ld"),
+        ),
+        tool_path(
+            name = "nm",
+            path = SDK_PATH_PREFIX.format("nm"),
+        ),
+        tool_path(
+            name = "objcopy",
+            path = SDK_PATH_PREFIX.format("objcopy"),
+        ),
+        tool_path(
+            name = "objdump",
+            path = SDK_PATH_PREFIX.format("objdump"),
+        ),
+        tool_path(
+            name = "ranlib",
+            path = SDK_PATH_PREFIX.format("ranlib"),
+        ),
+        tool_path(
+            name = "strip",
+            path = SDK_PATH_PREFIX.format("strip"),
+        ),
+    ]
+
+    features = [
+        feature(
+            name = "default_compile_actions",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.clif_match,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.preprocess_assemble,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/aarch64-linux-musl",
+                                "-no-canonical-prefixes",
+                                "-fno-canonical-system-headers",
+                                "-fno-common",
+                                "-ffunction-sections",
+                                "-fdata-sections",
+                                # Reproducibility
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+        feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/aarch64-linux-musl",
+                                "-Wl,-O1",
+                                "-Wl,--hash-style=gnu",
+                                "-Wl,--as-needed",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "musl-toolchain",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "musl",
+        target_libc = "unknown",
+        compiler = "gcc",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/cc/toolchains/musl/aarch64/musl.BUILD.bzl
+++ b/cc/toolchains/musl/aarch64/musl.BUILD.bzl
@@ -1,0 +1,83 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "gcc",
+    srcs = [
+        "bin/aarch64-linux-musl-cpp",
+        "bin/aarch64-linux-musl-g++",
+        "bin/aarch64-linux-musl-gcc",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = [
+        "bin/aarch64-linux-musl-ld",
+    ],
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "lib/gcc/aarch64-linux-musl/11.2.0/include/**",
+        "lib/gcc/aarch64-linux-musl/11.2.0/include-fixed/**",
+        "aarch64-linux-musl/include/**",
+    ]),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob([
+        "bin/**",
+        "aarch64-linux-musl/bin/**",
+    ]) + [
+        "libexec/gcc/aarch64-linux-musl/11.2.0/cc1",
+        "libexec/gcc/aarch64-linux-musl/11.2.0/cc1plus",
+        "libexec/gcc/aarch64-linux-musl/11.2.0/liblto_plugin.so",
+    ],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob([
+        "aarch64-linux-musl/lib/**",
+        "aarch64-linux-musl/**/lib*.a",  # ?
+        "lib/gcc/aarch64-linux-musl/11.2.0/**",
+        "lib/**/lib*.a",  # ?
+    ]),
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/aarch64-linux-musl-ar"],
+)
+
+filegroup(
+    name = "as",
+    srcs = ["bin/aarch64-linux-musl-as"],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/aarch64-linux-musl-nm"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/aarch64-linux-musl-objcopy"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/aarch64-linux-musl-objdump"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/aarch64-linux-musl-ranlib"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/aarch64-linux-musl-strip"],
+)

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ar
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-as
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-as
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-cpp
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-g++
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-g++
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-gcc
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-gcc
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-gcov
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-gcov
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ld
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ld
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-nm
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-objcopy
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-objcopy
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-objdump
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ranlib
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-ranlib
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-strip
+++ b/cc/toolchains/musl/aarch64/wrappers/aarch64-linux-musl-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+# Locates the actual tool paths relative to the location this script is 
+# executed from.
+#
+# This is necessary because we download the toolchain using
+# http_archive, which bazel places in _execroot_/external/_repo_name_.
+#
+# Unfortunately we cannot provide this location as the argument of tool_path
+# when configuring the toolchain, because tool_path only takes a relative path.
+#
+# This is the fairly common workaround to handle this.
+#
+# TODO: [BUILD-549] - Remove need for wrapper files
+#
+# Recent versions of Bazel may have introduced a mechanism that removes
+# the need for this workaround: https://github.com/bazelbuild/bazel/issues/7746
+
+set -e
+
+# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+  set -x
+fi
+
+tool_name=$(basename "${BASH_SOURCE[0]}")
+toolchain_bindir=external/aarch64-linux-musl/bin
+
+if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  # This branch exists because some users of the toolchain,
+  # namely rules_foreign_cc, will change CWD and call $CC (this script)
+  # with its absolute path.
+  #
+  # To deal with this we find the tool relative to this script, which is at
+  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/x86_64/wrappers/wrapper.
+  #
+  # If the wrapper is relocated then this line needs to be adjusted.
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
+  exec "${tool}" "${@}"
+else
+  >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
+  exit 5
+fi
+

--- a/cc/toolchains/musl/armhf/BUILD.bazel
+++ b/cc/toolchains/musl/armhf/BUILD.bazel
@@ -1,0 +1,110 @@
+load(":config.bzl", "config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:ar",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "as_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:as",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:bin",
+        "@arm-linux-musleabihf//:include",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:ar",
+        "@arm-linux-musleabihf//:gcc",
+        "@arm-linux-musleabihf//:ld",
+        "@arm-linux-musleabihf//:lib",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:objcopy",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        ":wrappers",
+        "@arm-linux-musleabihf//:strip",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":compiler_files",
+        ":linker_files",
+        "@arm-linux-musleabihf//:bin",
+    ],
+    tags = ["manual"],
+)
+
+config(name = "config")
+
+cc_toolchain(
+    name = "cc_toolchain",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    as_files = ":as_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+    tags = ["manual"],
+    toolchain_config = ":config",
+    toolchain_identifier = "step-toolchain",
+)
+
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+    ],
+    toolchain = ":cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/cc/toolchains/musl/armhf/BUILD.bazel
+++ b/cc/toolchains/musl/armhf/BUILD.bazel
@@ -104,6 +104,7 @@ toolchain(
     target_compatible_with = [
         "@platforms//os:linux",
         "@platforms//cpu:arm",
+        "//cc/constraints:musl",
     ],
     toolchain = ":cc_toolchain",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",

--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -76,6 +76,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
+                                "--sysroot=external/arm-linux-musleabihf",
                                 "-no-canonical-prefixes",
                                 "-fno-canonical-system-headers",
                                 "-fno-common",
@@ -105,6 +106,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
+                                "--sysroot=external/arm-linux-musleabihf",
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",

--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -1,0 +1,137 @@
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+SDK_PATH_PREFIX = "wrappers/arm-linux-musleabihf-{}"
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "ar",
+            path = SDK_PATH_PREFIX.format("ar"),
+        ),
+        tool_path(
+            name = "as",
+            path = SDK_PATH_PREFIX.format("as"),
+        ),
+        tool_path(
+            name = "cpp",
+            path = SDK_PATH_PREFIX.format("cpp"),
+        ),
+        tool_path(
+            name = "gcc",
+            path = SDK_PATH_PREFIX.format("gcc"),
+        ),
+        tool_path(
+            name = "g++",
+            path = SDK_PATH_PREFIX.format("g++"),
+        ),
+        tool_path(
+            name = "gcov",
+            path = SDK_PATH_PREFIX.format("gcov"),
+        ),
+        tool_path(
+            name = "ld",
+            path = SDK_PATH_PREFIX.format("ld"),
+        ),
+        tool_path(
+            name = "nm",
+            path = SDK_PATH_PREFIX.format("nm"),
+        ),
+        tool_path(
+            name = "objcopy",
+            path = SDK_PATH_PREFIX.format("objcopy"),
+        ),
+        tool_path(
+            name = "objdump",
+            path = SDK_PATH_PREFIX.format("objdump"),
+        ),
+        tool_path(
+            name = "ranlib",
+            path = SDK_PATH_PREFIX.format("ranlib"),
+        ),
+        tool_path(
+            name = "strip",
+            path = SDK_PATH_PREFIX.format("strip"),
+        ),
+    ]
+
+    features = [
+        feature(
+            name = "default_compile_actions",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.clif_match,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.preprocess_assemble,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-fno-canonical-system-headers",
+                                "-fno-common",
+                                "-ffunction-sections",
+                                "-fdata-sections",
+                                # Reproducibility
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+        feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "-Wl,-O1",
+                                "-Wl,--hash-style=gnu",
+                                "-Wl,--as-needed",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "musl-toolchain",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "musl",
+        target_libc = "unknown",
+        compiler = "gcc",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -107,7 +107,6 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "--sysroot=external/arm-linux-musleabihf",
-                                "-Wl,--gc-sections",
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",

--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -107,6 +107,7 @@ def _impl(ctx):
                         flag_group(
                             flags = [
                                 "--sysroot=external/arm-linux-musleabihf",
+                                "-Wl,--gc-sections",
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",

--- a/cc/toolchains/musl/armhf/musl.BUILD.bzl
+++ b/cc/toolchains/musl/armhf/musl.BUILD.bzl
@@ -1,0 +1,83 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "gcc",
+    srcs = [
+        "bin/arm-linux-musleabihf-cpp",
+        "bin/arm-linux-musleabihf-g++",
+        "bin/arm-linux-musleabihf-gcc",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = [
+        "bin/arm-linux-musleabihf-ld",
+    ],
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "lib/gcc/arm-linux-musleabihf/11.2.0/include/**",
+        "lib/gcc/arm-linux-musleabihf/11.2.0/include-fixed/**",
+        "arm-linux-musleabihf/include/**",
+    ]),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob([
+        "bin/**",
+        "arm-linux-musleabihf/bin/**",
+    ]) + [
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/cc1",
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/cc1plus",
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/liblto_plugin.so",
+    ],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob([
+        "arm-linux-musleabihf/lib/**",
+        "arm-linux-musleabihf/**/lib*.a",  # ?
+        "lib/gcc/arm-linux-musleabihf/11.2.0/**",
+        "lib/**/lib*.a",  # ?
+    ]),
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/arm-linux-musleabihf-ar"],
+)
+
+filegroup(
+    name = "as",
+    srcs = ["bin/arm-linux-musleabihf-as"],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/arm-linux-musleabihf-nm"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/arm-linux-musleabihf-objcopy"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/arm-linux-musleabihf-objdump"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/arm-linux-musleabihf-ranlib"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/arm-linux-musleabihf-strip"],
+)

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ar
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-as
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-as
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-cpp
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-g++
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-g++
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-gcc
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-gcc
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-gcov
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-gcov
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ld
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ld
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-nm
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-objcopy
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-objcopy
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-objdump
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ranlib
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-ranlib
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-strip
+++ b/cc/toolchains/musl/armhf/wrappers/arm-linux-musleabihf-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+# Locates the actual tool paths relative to the location this script is 
+# executed from.
+#
+# This is necessary because we download the toolchain using
+# http_archive, which bazel places in _execroot_/external/_repo_name_.
+#
+# Unfortunately we cannot provide this location as the argument of tool_path
+# when configuring the toolchain, because tool_path only takes a relative path.
+#
+# This is the fairly common workaround to handle this.
+#
+# TODO: [BUILD-549] - Remove need for wrapper files
+#
+# Recent versions of Bazel may have introduced a mechanism that removes
+# the need for this workaround: https://github.com/bazelbuild/bazel/issues/7746
+
+set -e
+
+# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+  set -x
+fi
+
+tool_name=$(basename "${BASH_SOURCE[0]}")
+toolchain_bindir=external/arm-linux-musleabihf/bin
+
+if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  # This branch exists because some users of the toolchain,
+  # namely rules_foreign_cc, will change CWD and call $CC (this script)
+  # with its absolute path.
+  #
+  # To deal with this we find the tool relative to this script, which is at
+  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/armhf/wrappers/wrapper.
+  #
+  # If the wrapper is relocated then this line needs to be adjusted.
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
+  exec "${tool}" "${@}"
+else
+  >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
+  exit 5
+fi
+

--- a/cc/toolchains/musl/musl.BUILD.bzl
+++ b/cc/toolchains/musl/musl.BUILD.bzl
@@ -41,9 +41,9 @@ filegroup(
     name = "lib",
     srcs = glob([
         "arm-linux-musleabihf/lib/**",
-        "arm-linux-musleabihf/**/lib*.a", # ?
+        "arm-linux-musleabihf/**/lib*.a",  # ?
         "lib/gcc/arm-linux-musleabihf/11.2.0/**",
-        "lib/**/lib*.a", # ?
+        "lib/**/lib*.a",  # ?
     ]),
 )
 

--- a/cc/toolchains/musl/musl.BUILD.bzl
+++ b/cc/toolchains/musl/musl.BUILD.bzl
@@ -1,0 +1,80 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "gcc",
+    srcs = [
+        "bin/arm-linux-musleabifh-cpp",
+        "bin/arm-linux-musleabifh-g++",
+        "bin/arm-linux-musleabifh-gcc",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = [
+        "bin/arm-linux-musleabifh-ld",
+    ],
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "lib/gcc/arm-linux-musleabifh/11.2.0/include/**",
+        "lib/gcc/arm-linux-musleabifh/11.2.0/include-fixed/**",
+        "arm-linux-musleabifh/include/**",
+    ]),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob([
+        "bin/**",
+        "arm-linux-musleabifh/bin/**",
+    ]) + [
+        "libexec/gcc/arm-linux-musleabifh/11.2.0/cc1",
+        "libexec/gcc/arm-linux-musleabifh/11.2.0/cc1plus",
+    ],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob([
+        "arm-linux-musleabifh/**/lib*.a",
+        "lib/**/lib*.a",
+    ]),
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/arm-linux-musleabifh-ar"],
+)
+
+filegroup(
+    name = "as",
+    srcs = ["bin/arm-linux-musleabifh-as"],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/arm-linux-musleabifh-nm"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/arm-linux-musleabifh-objcopy"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/arm-linux-musleabifh-objdump"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/arm-linux-musleabifh-ranlib"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/arm-linux-musleabifh-strip"],
+)

--- a/cc/toolchains/musl/musl.BUILD.bzl
+++ b/cc/toolchains/musl/musl.BUILD.bzl
@@ -3,25 +3,25 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "gcc",
     srcs = [
-        "bin/arm-linux-musleabifh-cpp",
-        "bin/arm-linux-musleabifh-g++",
-        "bin/arm-linux-musleabifh-gcc",
+        "bin/arm-linux-musleabihf-cpp",
+        "bin/arm-linux-musleabihf-g++",
+        "bin/arm-linux-musleabihf-gcc",
     ],
 )
 
 filegroup(
     name = "ld",
     srcs = [
-        "bin/arm-linux-musleabifh-ld",
+        "bin/arm-linux-musleabihf-ld",
     ],
 )
 
 filegroup(
     name = "include",
     srcs = glob([
-        "lib/gcc/arm-linux-musleabifh/11.2.0/include/**",
-        "lib/gcc/arm-linux-musleabifh/11.2.0/include-fixed/**",
-        "arm-linux-musleabifh/include/**",
+        "lib/gcc/arm-linux-musleabihf/11.2.0/include/**",
+        "lib/gcc/arm-linux-musleabihf/11.2.0/include-fixed/**",
+        "arm-linux-musleabihf/include/**",
     ]),
 )
 
@@ -29,52 +29,55 @@ filegroup(
     name = "bin",
     srcs = glob([
         "bin/**",
-        "arm-linux-musleabifh/bin/**",
+        "arm-linux-musleabihf/bin/**",
     ]) + [
-        "libexec/gcc/arm-linux-musleabifh/11.2.0/cc1",
-        "libexec/gcc/arm-linux-musleabifh/11.2.0/cc1plus",
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/cc1",
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/cc1plus",
+        "libexec/gcc/arm-linux-musleabihf/11.2.0/liblto_plugin.so",
     ],
 )
 
 filegroup(
     name = "lib",
     srcs = glob([
-        "arm-linux-musleabifh/**/lib*.a",
-        "lib/**/lib*.a",
+        "arm-linux-musleabihf/lib/**",
+        "arm-linux-musleabihf/**/lib*.a", # ?
+        "lib/gcc/arm-linux-musleabihf/11.2.0/**",
+        "lib/**/lib*.a", # ?
     ]),
 )
 
 filegroup(
     name = "ar",
-    srcs = ["bin/arm-linux-musleabifh-ar"],
+    srcs = ["bin/arm-linux-musleabihf-ar"],
 )
 
 filegroup(
     name = "as",
-    srcs = ["bin/arm-linux-musleabifh-as"],
+    srcs = ["bin/arm-linux-musleabihf-as"],
 )
 
 filegroup(
     name = "nm",
-    srcs = ["bin/arm-linux-musleabifh-nm"],
+    srcs = ["bin/arm-linux-musleabihf-nm"],
 )
 
 filegroup(
     name = "objcopy",
-    srcs = ["bin/arm-linux-musleabifh-objcopy"],
+    srcs = ["bin/arm-linux-musleabihf-objcopy"],
 )
 
 filegroup(
     name = "objdump",
-    srcs = ["bin/arm-linux-musleabifh-objdump"],
+    srcs = ["bin/arm-linux-musleabihf-objdump"],
 )
 
 filegroup(
     name = "ranlib",
-    srcs = ["bin/arm-linux-musleabifh-ranlib"],
+    srcs = ["bin/arm-linux-musleabihf-ranlib"],
 )
 
 filegroup(
     name = "strip",
-    srcs = ["bin/arm-linux-musleabifh-strip"],
+    srcs = ["bin/arm-linux-musleabihf-strip"],
 )

--- a/cc/toolchains/musl/x86_64/BUILD.bazel
+++ b/cc/toolchains/musl/x86_64/BUILD.bazel
@@ -1,0 +1,111 @@
+load(":config.bzl", "config")
+
+filegroup(name = "empty")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:ar",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "as_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:as",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:bin",
+        "@x86_64-linux-musl//:include",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:ar",
+        "@x86_64-linux-musl//:gcc",
+        "@x86_64-linux-musl//:ld",
+        "@x86_64-linux-musl//:lib",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:objcopy",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-musl//:strip",
+    ],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        ":compiler_files",
+        ":linker_files",
+        "@x86_64-linux-musl//:bin",
+    ],
+    tags = ["manual"],
+)
+
+config(name = "config")
+
+cc_toolchain(
+    name = "cc_toolchain",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    as_files = ":as_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":empty",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    supports_param_files = 0,
+    tags = ["manual"],
+    toolchain_config = ":config",
+    toolchain_identifier = "x86_64-linux-musl",
+)
+
+toolchain(
+    name = "toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+        "//cc/constraints:musl",
+    ],
+    toolchain = ":cc_toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/cc/toolchains/musl/x86_64/config.bzl
+++ b/cc/toolchains/musl/x86_64/config.bzl
@@ -1,0 +1,139 @@
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+SDK_PATH_PREFIX = "wrappers/x86_64-linux-musl-{}"
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(
+            name = "ar",
+            path = SDK_PATH_PREFIX.format("ar"),
+        ),
+        tool_path(
+            name = "as",
+            path = SDK_PATH_PREFIX.format("as"),
+        ),
+        tool_path(
+            name = "cpp",
+            path = SDK_PATH_PREFIX.format("cpp"),
+        ),
+        tool_path(
+            name = "gcc",
+            path = SDK_PATH_PREFIX.format("gcc"),
+        ),
+        tool_path(
+            name = "g++",
+            path = SDK_PATH_PREFIX.format("g++"),
+        ),
+        tool_path(
+            name = "gcov",
+            path = SDK_PATH_PREFIX.format("gcov"),
+        ),
+        tool_path(
+            name = "ld",
+            path = SDK_PATH_PREFIX.format("ld"),
+        ),
+        tool_path(
+            name = "nm",
+            path = SDK_PATH_PREFIX.format("nm"),
+        ),
+        tool_path(
+            name = "objcopy",
+            path = SDK_PATH_PREFIX.format("objcopy"),
+        ),
+        tool_path(
+            name = "objdump",
+            path = SDK_PATH_PREFIX.format("objdump"),
+        ),
+        tool_path(
+            name = "ranlib",
+            path = SDK_PATH_PREFIX.format("ranlib"),
+        ),
+        tool_path(
+            name = "strip",
+            path = SDK_PATH_PREFIX.format("strip"),
+        ),
+    ]
+
+    features = [
+        feature(
+            name = "default_compile_actions",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.assemble,
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_codegen,
+                        ACTION_NAMES.cpp_module_compile,
+                        ACTION_NAMES.clif_match,
+                        ACTION_NAMES.linkstamp_compile,
+                        ACTION_NAMES.lto_backend,
+                        ACTION_NAMES.preprocess_assemble,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/x86_64-linux-musl",
+                                "-no-canonical-prefixes",
+                                "-fno-canonical-system-headers",
+                                "-fno-common",
+                                "-ffunction-sections",
+                                "-fdata-sections",
+                                # Reproducibility
+                                "-Wno-builtin-macro-redefined",
+                                "-D__DATE__=\"redacted\"",
+                                "-D__TIMESTAMP__=\"redacted\"",
+                                "-D__TIME__=\"redacted\"",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+        feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = ([
+                        flag_group(
+                            flags = [
+                                "--sysroot=external/x86_64-linux-musl",
+                                "-Wl,-O1",
+                                "-Wl,--hash-style=gnu",
+                                "-Wl,--as-needed",
+                            ],
+                        ),
+                    ]),
+                ),
+            ],
+        ),
+    ]
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        toolchain_identifier = "musl-toolchain",
+        host_system_name = "local",
+        target_system_name = "local",
+        target_cpu = "musl",
+        target_libc = "unknown",
+        compiler = "gcc",
+        abi_version = "unknown",
+        abi_libc_version = "unknown",
+        tool_paths = tool_paths,
+    )
+
+config = rule(
+    implementation = _impl,
+    attrs = {},
+    provides = [CcToolchainConfigInfo],
+)

--- a/cc/toolchains/musl/x86_64/musl.BUILD.bzl
+++ b/cc/toolchains/musl/x86_64/musl.BUILD.bzl
@@ -1,0 +1,83 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "gcc",
+    srcs = [
+        "bin/x86_64-linux-musl-cpp",
+        "bin/x86_64-linux-musl-g++",
+        "bin/x86_64-linux-musl-gcc",
+    ],
+)
+
+filegroup(
+    name = "ld",
+    srcs = [
+        "bin/x86_64-linux-musl-ld",
+    ],
+)
+
+filegroup(
+    name = "include",
+    srcs = glob([
+        "lib/gcc/x86_64-linux-musl/11.2.0/include/**",
+        "lib/gcc/x86_64-linux-musl/11.2.0/include-fixed/**",
+        "x86_64-linux-musl/include/**",
+    ]),
+)
+
+filegroup(
+    name = "bin",
+    srcs = glob([
+        "bin/**",
+        "x86_64-linux-musl/bin/**",
+    ]) + [
+        "libexec/gcc/x86_64-linux-musl/11.2.0/cc1",
+        "libexec/gcc/x86_64-linux-musl/11.2.0/cc1plus",
+        "libexec/gcc/x86_64-linux-musl/11.2.0/liblto_plugin.so",
+    ],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob([
+        "x86_64-linux-musl/lib/**",
+        "x86_64-linux-musl/**/lib*.a",  # ?
+        "lib/gcc/x86_64-linux-musl/11.2.0/**",
+        "lib/**/lib*.a",  # ?
+    ]),
+)
+
+filegroup(
+    name = "ar",
+    srcs = ["bin/x86_64-linux-musl-ar"],
+)
+
+filegroup(
+    name = "as",
+    srcs = ["bin/x86_64-linux-musl-as"],
+)
+
+filegroup(
+    name = "nm",
+    srcs = ["bin/x86_64-linux-musl-nm"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/x86_64-linux-musl-objcopy"],
+)
+
+filegroup(
+    name = "objdump",
+    srcs = ["bin/x86_64-linux-musl-objdump"],
+)
+
+filegroup(
+    name = "ranlib",
+    srcs = ["bin/x86_64-linux-musl-ranlib"],
+)
+
+filegroup(
+    name = "strip",
+    srcs = ["bin/x86_64-linux-musl-strip"],
+)

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+# Locates the actual tool paths relative to the location this script is 
+# executed from.
+#
+# This is necessary because we download the toolchain using
+# http_archive, which bazel places in _execroot_/external/_repo_name_.
+#
+# Unfortunately we cannot provide this location as the argument of tool_path
+# when configuring the toolchain, because tool_path only takes a relative path.
+#
+# This is the fairly common workaround to handle this.
+#
+# TODO: [BUILD-549] - Remove need for wrapper files
+#
+# Recent versions of Bazel may have introduced a mechanism that removes
+# the need for this workaround: https://github.com/bazelbuild/bazel/issues/7746
+
+set -e
+
+# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+  set -x
+fi
+
+tool_name=$(basename "${BASH_SOURCE[0]}")
+toolchain_bindir=external/x86_64-linux-musl/bin
+
+if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  # This branch exists because some users of the toolchain,
+  # namely rules_foreign_cc, will change CWD and call $CC (this script)
+  # with its absolute path.
+  #
+  # To deal with this we find the tool relative to this script, which is at
+  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/x86_64/wrappers/wrapper.
+  #
+  # If the wrapper is relocated then this line needs to be adjusted.
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
+  exec "${tool}" "${@}"
+else
+  >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
+  exit 5
+fi
+

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ar
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-as
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-as
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-cpp
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-g++
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-g++
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-gcc
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-gcc
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-gcov
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-gcov
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ld
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ld
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-nm
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-objcopy
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-objcopy
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-objdump
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ranlib
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-ranlib
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-strip
+++ b/cc/toolchains/musl/x86_64/wrappers/x86_64-linux-musl-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -8,6 +8,8 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+package(default_visibility = ["//visibility:public"])
+
 platform(
     name = "cortex_m4_none_eabi",
     constraint_values = [
@@ -53,5 +55,32 @@ platform(
     constraint_values = [
         "@platforms//os:none",
         "//cc/constraints:unspecified_arm",
+    ],
+)
+
+platform(
+    name = "aarch64_linux_musl",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        "//cc/constraints:musl",
+    ],
+)
+
+platform(
+    name = "arm_linux_musleabihf",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+        "//cc/constraints:musl",
+    ],
+)
+
+platform(
+    name = "x86_64_linux_musl",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+        "//cc/constraints:musl",
     ],
 )


### PR DESCRIPTION
Adds a toolchain for targeting `arm-linux-musleabihf` that is compatible with the corresponding rust toolchain.

The build is based on gcc v11.2.0 and musl v1.1.24

# Testing
- https://github.com/swift-nav/bird-sweater/pull/187
- https://github.com/swift-nav/starling/pull/7912

# Related PRs
- https://github.com/swift-nav/swift-toolchains/pull/17

# TODO

- [x]  Add sha256 once toolchain is finalized