### PR TITLE
Introduce default toolchain constraint value [BUILD-664]

### DIFF
--- a/cc/constraints/BUILD.bazel
+++ b/cc/constraints/BUILD.bazel
@@ -2,9 +2,17 @@ load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = ["//visibility:public"])
 
-constraint_setting(name = "compiler")
+constraint_setting(
+    name = "toolchain",
+    default_constraint_value = ":llvm_toolchain",
+)
 
-constraint_setting(name = "toolchain")
+constraint_value(
+    name = "llvm_toolchain",
+    constraint_setting = ":toolchain",
+)
+
+constraint_setting(name = "compiler")
 
 constraint_value(
     name = "gcc-5",

--- a/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
@@ -142,6 +142,7 @@ toolchain(
     target_compatible_with = [
         "@platforms//cpu:aarch64",
         "@platforms//os:macos",
+        "//cc/constraints:llvm_toolchain",
     ],
     target_settings = None,
     toolchain = ":cc-clang-aarch64-darwin",

--- a/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
@@ -143,6 +143,7 @@ toolchain(
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:macos",
+        "//cc/constraints:llvm_toolchain",
     ],
     target_settings = None,
     toolchain = ":cc-clang-x86_64-darwin",

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -142,6 +142,7 @@ toolchain(
     target_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
+        "//cc/constraints:llvm_toolchain",
     ],
     target_settings = None,
     toolchain = ":cc-clang-x86_64-linux",


### PR DESCRIPTION
This PR adds the `llvm_toolchain` constraint value to improve toolchain recognition. 