### PR TITLE
Add Intel MKL support for Eigen on Linux[AI-74]

### DIFF
--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -20,7 +20,7 @@ cc_library(
     defines = [
         "EIGEN_NO_DEBUG",
     ] + select({
-        "x86_64-linux_and_mkl": ["EIGEN_USE_MKL_ALL"],
+        "@rules_swiftnav//third_party:_enable_mkl": ["EIGEN_USE_MKL_ALL"],
         "//conditions:default": [],
     }),
     includes = ["."],

--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2023 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -8,8 +8,18 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 package(
     default_visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "x86_64-linux_and_mkl",
+    match_all = [
+        "@rules_swiftnav//platforms:x86_64-linux",
+        "@rules_swiftnav//third_party:_enable_mkl",
+    ],
 )
 
 cc_library(
@@ -17,6 +27,13 @@ cc_library(
     hdrs = glob(["Eigen/**"]),
     defines = [
         "EIGEN_NO_DEBUG",
-    ],
+    ] + select({
+        "x86_64-linux_and_mkl": ["EIGEN_USE_MKL_ALL"],
+        "//conditions:default": [],
+    }),
     includes = ["."],
+    deps = select({
+        "x86_64-linux_and_mkl": ["@mkl_libraries"],
+        "//conditions:default": [],
+    }),
 )

--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -24,7 +24,7 @@ cc_library(
     }),
     includes = ["."],
     deps = select({
-        "x86_64-linux_and_mkl": ["@mkl_libraries"],
+        "@rules_swiftnav//third_party:_enable_mkl": ["@mkl_libraries"],
         "//conditions:default": [],
     }),
 )

--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -8,7 +8,6 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -14,14 +14,6 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
-selects.config_setting_group(
-    name = "x86_64-linux_and_mkl",
-    match_all = [
-        "@rules_swiftnav//platforms:x86_64-linux",
-        "@rules_swiftnav//third_party:_enable_mkl",
-    ],
-)
-
 cc_library(
     name = "eigen",
     hdrs = glob(["Eigen/**"]),

--- a/third_party/eigen.BUILD
+++ b/third_party/eigen.BUILD
@@ -8,7 +8,6 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-
 package(
     default_visibility = ["//visibility:public"],
 )
@@ -24,7 +23,7 @@ cc_library(
     }),
     includes = ["."],
     deps = select({
-        "@rules_swiftnav//third_party:_enable_mkl": ["@mkl_libraries"],
+        "@rules_swiftnav//third_party:_enable_mkl": ["@mkl"],
         "//conditions:default": [],
     }),
 )

--- a/third_party/mkl.BUILD
+++ b/third_party/mkl.BUILD
@@ -29,7 +29,7 @@ cc_import(
 )
 
 cc_library(
-    name = "mkl_libraries",
+    name = "mkl",
     copts = ["-fopenmp"],
     linkopts = [
         "-l:libgomp.a",

--- a/third_party/mkl_headers.BUILD
+++ b/third_party/mkl_headers.BUILD
@@ -13,6 +13,10 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "mkl_headers",
     hdrs = glob(["include/*.h"]),
-    includes = ["include/"],
+    includes = ["include"],
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+     }),
     visibility = ["//visibility:public"],
 )

--- a/third_party/mkl_headers.BUILD
+++ b/third_party/mkl_headers.BUILD
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2023 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -8,21 +8,11 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
-bool_flag(
-    name = "enable_mkl",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
-)
-
-config_setting(
-    name = "_enable_mkl",
-    flag_values = {":enable_mkl": "true"},
-    visibility = ["//visibility:public"],
-)
-
-exports_files(
-    glob(["*.BUILD"]),
+cc_library(
+    name = "mkl_headers",
+    hdrs = glob(["include/*.h"]),
+    includes = ["include/"],
     visibility = ["//visibility:public"],
 )

--- a/third_party/mkl_headers.BUILD
+++ b/third_party/mkl_headers.BUILD
@@ -17,6 +17,6 @@ cc_library(
     target_compatible_with = select({
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
-     }),
+    }),
     visibility = ["//visibility:public"],
 )

--- a/third_party/mkl_libraries.BUILD
+++ b/third_party/mkl_libraries.BUILD
@@ -1,0 +1,46 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+
+cc_import(
+    name = "libmkl_core",
+    static_library = "libmkl_core.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "libmkl_intel_lp64",
+    static_library = "libmkl_intel_lp64.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_import(
+    name = "libmkl_gnu_thread",
+    static_library = "libmkl_gnu_thread.a",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mkl_libraries",
+    copts = ["-fopenmp"],
+    linkopts = [
+        "-l:libgomp.a",
+    ],
+    linkstatic = 1,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":libmkl_core",
+        ":libmkl_gnu_thread",
+        ":libmkl_intel_lp64",
+        "@mkl_headers",
+    ],
+    alwayslink = 1,
+)


### PR DESCRIPTION
## Implements
* Adds two third_party build files one for MKL headers and one for MKL static libraries. This choice was mainly driven by Intel's choice of distribution method.
* Adds a new boolean flag enable_mkl which defaults to False but can be used to trigger linking and enabling MKL with eigen.

## Testing
* I have validated locally using this in one of our internal repos and I have deployed it to a live network which shows comparable performance to prior cmake implementations.

## Usage
`WORKSPACE`
```
http_archive(
    name = "mkl_headers",
    build_file = "@rules_swiftnav//third_party:mkl_headers.BUILD",
    sha256 = "2490d0741ea4eb2b5618defa7faeb51b4362fe3614bd602365e8fbb4829eac58",
    urls = [
        "https://anaconda.org/intel/mkl-include/2023.1.0/download/linux-64/mkl-include-2023.1.0-intel_46342.tar.bz2",
    ],
)
http_archive(
    name = "mkl_libraries",
    build_file = "@rules_swiftnav//third_party:mkl_libraries.BUILD",
    strip_prefix = "lib",
    sha256 = "c63adbfdbdc7c4992384a2d89cd62211e4a9f8061e3e841af1a269699531cb02",
    urls = [
        "https://anaconda.org/intel/mkl-static/2023.1.0/download/linux-64/mkl-static-2023.1.0-intel_46342.tar.bz2",
    ],
)
```

`.bazelrc`
```
build:mkl --@rules_swiftnav//third_party:enable_mkl=true
```

## Related
* Here are links to where I have been grabbing the static libraries and headers. AFAICT, it seems to be official Intel but there is always some level of risk relying on external hosting.
https://anaconda.org/intel/mkl-static
https://anaconda.org/intel/mkl-include

## Future Work
Although this is working I could see us iterating on it a bit more.
* AVX support.
* Support osx architectures.
* There are other libraries and features that MKL offers which we could add.
* We could in theory host the static libraries / headers for all supported architectures ourselves and then combine them all into a single .tar.bz file which could allow us to get away wiith a single BUILD file and smaller footprint for users' WORKSPACE files.