### PR TITLE
netcdf: fix broken config setting on aarch64-darwin

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -8,7 +8,15 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-package(default_visibility = ["//visibility:public"])
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+config_setting(
+    name = "aarch64_darwin",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:macos",
+    ],
+)
 
 platform(
     name = "cortex_m4_none_eabi",

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -132,7 +132,7 @@ genrule(
     outs = ["config.h"],
     cmd = select(
         {
-            "@bazel_tools//src/conditions:darwin_arm64": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
+            "@bazel_tools//src/conditions:darwin_arm64_constraint": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
             "@bazel_tools//src/conditions:darwin_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_DARWIN_CONFIG),
             "@bazel_tools//src/conditions:linux_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
         },

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -132,7 +132,7 @@ genrule(
     outs = ["config.h"],
     cmd = select(
         {
-            "@bazel_tools//src/conditions:darwin_arm64_constraint": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
+            "@rules_swiftnav//platforms:aarch64_darwin": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
             "@bazel_tools//src/conditions:darwin_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_DARWIN_CONFIG),
             "@bazel_tools//src/conditions:linux_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
         },


### PR DESCRIPTION
We switched from using our on hand-rolled mechanism for detecting
and switching on platform (x86_64-linux, aarch64-darwin, etc..), to some
OTB bazel provided targets.

It seems like their solution for aarch64-darwin doesn't actually work properly,
so I'm reverting it back to our own mechanism. It's likely we should file a bug
upstream.

# Testing
- I tested the fix on m1 mac