### PR TITLE
Generate clang-tidy-fixes [BUILD-686]

### DIFF
--- a/clang_tidy/BUILD.bazel
+++ b/clang_tidy/BUILD.bazel
@@ -50,3 +50,9 @@ label_flag(
     build_setting_default = ":clang_tidy_additional_deps_default",
     visibility = ["//visibility:public"],
 )
+
+sh_binary(
+    name = "clang_tidy_fixes",
+    srcs = ["clang_tidy_fixes.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/clang_tidy/clang_tidy_fixes.sh
+++ b/clang_tidy/clang_tidy_fixes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd $BUILD_WORKSPACE_DIRECTORY
+
+find ./bazel-out/ -path '*bazel_clang_tidy_*.clang-tidy.yaml' -exec cat {} + > clang_tidy_fixes.txt
+
+echo "Clang tidy fixes are stored in the $PWD/clang_tidy_fixes.txt file"


### PR DESCRIPTION
Usage:
`bazel run @rules_swiftnav//clang_tidy:clang_tidy_fixes`

Clang tidy fixes files for each target are created here: https://github.com/swift-nav/rules_swiftnav/blob/f0a37974a4b2605c6c88ec01c0de16b53e0c1221/clang_tidy/clang_tidy.bzl#L16
The `clang_tidy_fixes` target merges these files into `clang_tidy_fixes.txt`.
