### PR TITLE
Add mkl srcs and linkopts

### DIFF
--- a/third_party/mkl.BUILD
+++ b/third_party/mkl.BUILD
@@ -30,8 +30,18 @@ cc_import(
 
 cc_library(
     name = "mkl",
+    srcs = [
+        "@mkl//:libmkl_core.a",
+        "@mkl//:libmkl_gnu_thread.a",
+        "@mkl//:libmkl_intel_lp64.a",
+    ],
     copts = ["-fopenmp"],
     linkopts = [
+        "-Wl,--start-group",
+        "$(location @mkl//:libmkl_intel_lp64.a)",
+        "$(location @mkl//:libmkl_core.a)",
+        "$(location @mkl//:libmkl_gnu_thread.a)",
+        "-Wl,--end-group",
         "-l:libgomp.a",
     ],
     linkstatic = 1,


### PR DESCRIPTION
## Implements
* Adds mkl static libraries to the library srcs and linkopts to fix a bug when compiling with g++.

## Testing
* Tested building run_replay in orion-engine with and without "--config=mkl"; however, the "-flto" flag for turbo is still broken for --config=system so we may need to decouple that from "--config=mkl" where it is used until we squash our own warnings and figure out a way to deal with external warnings, such as fast_csv.