### PR TITLE
Fix SonarCloud config [BUILD-688]

### DIFF
--- a/cc_files/get_cc_files.bzl
+++ b/cc_files/get_cc_files.bzl
@@ -3,6 +3,7 @@ load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY", "TEST_SRCS")
 FilesInfo = provider(
     fields = {
         "files": "files of the target",
+        "test_files": "test files of the target",
     },
 )
 
@@ -34,13 +35,17 @@ def get_cc_files(ctx):
 
 def _get_cc_target_files_impl(target, ctx):
     if not CcInfo in target:
-        return [FilesInfo(files = [])]
+        return [FilesInfo(files = [], test_files = [])]
 
     tags = getattr(ctx.rule.attr, "tags", [])
-    if not LIBRARY in tags and not TEST_LIBRARY in tags and not BINARY in tags:
-        return [FilesInfo(files = [])]
 
-    return [FilesInfo(files = get_cc_files(ctx))]
+    if LIBRARY in tags or BINARY in tags:
+        return [FilesInfo(files = get_cc_files(ctx), test_files = [])]
+
+    if TEST_LIBRARY in tags:
+        return [FilesInfo(files = [], test_files = get_cc_files(ctx))]
+
+    return [FilesInfo(files = [], test_files = [])]
 
 get_cc_target_files = aspect(
     implementation = _get_cc_target_files_impl,

--- a/tools/gen_sonar_cfg.bzl
+++ b/tools/gen_sonar_cfg.bzl
@@ -2,36 +2,65 @@ load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//cc_files:get_cc_files.bzl", "FilesInfo", "get_cc_target_files")
 
 def _gen_sonar_cfg_impl(ctx):
-    all_files_bash = ""
-    all_files = []
+    files_bash = ""
+    files = []
 
     for target in ctx.attr.targets:
-        for file in target[FilesInfo].files + ctx.files.test_srcs:
-            if file.path not in all_files:
-                all_files_bash += file.path
-                all_files_bash += " "
-                all_files.append(file.path)
+        for file in target[FilesInfo].files:
+            if file.path not in files:
+                files_bash += file.path
+                files_bash += " "
+                files.append(file.path)
+
+    test_files_bash = ""
+    test_files = []
+
+    for target in ctx.attr.targets:
+        for file in target[FilesInfo].test_files:
+            if file.path not in test_files:
+                test_files_bash += file.path
+                test_files_bash += " "
+                test_files.append(file.path)
+
+    for file in ctx.files.test_srcs:
+        if file.path not in test_files:
+            test_files_bash += file.path
+            test_files_bash += " "
+            test_files.append(file.path)
 
     out = ctx.actions.declare_file("sonar-project.properties")
     ctx.actions.run_shell(
         outputs = [out],
         command = """
+        add_files () {{
+            files=$1
+            first=1
+            for file in $files; do
+                if [[ $first -eq 1 ]]
+                then
+                    first=0
+                else
+                    echo ',\\' >> {out_file}
+                fi
+                echo -n "  {root_dir}/$file" >> {out_file}
+            done
+            echo '' >> {out_file}
+        }}
+
         echo 'sonar.sourceEncoding=UTF-8' >> {out_file}
-        echo 'sonar.sources=\\' >> {out_file}
-        first=1
-        for file in {all_files}; do
-            if [[ $first -eq 1 ]]
-            then
-                first=0
-            else
-                echo ',\\' >> {out_file}
-            fi
-            echo -n "  {root_dir}/$file" >> {out_file}
-        done
-        echo '' >> {out_file}
+
+        echo 'sonar.inclusions=\\' >> {out_file}
+        add_files "{inclusions}"
+
+        echo 'sonar.coverage.exclusions=\\' >> {out_file}
+        add_files "{exclusions}"
+
+        echo 'sonar.cpd.exclusions=\\' >> {out_file}
+        add_files "{exclusions}"
         """.format(
             out_file = out.path,
-            all_files = all_files_bash,
+            inclusions = files_bash + " " + test_files_bash,
+            exclusions = test_files_bash,
             root_dir = ctx.attr.root_dir[BuildSettingInfo].value,
         ),
     )


### PR DESCRIPTION
Now `gen_sonar_cfg` uses `sonar.inclusions`, `sonar.coverage.exclusions` and `sonar.cpd.exclusions` instead of `sonar.sources`.