### PR TITLE
Add support for cross-compiling from x86_64 to aarch64 linux [CLARM-14]

### DIFF
--- a/cc/constraints/BUILD.bazel
+++ b/cc/constraints/BUILD.bazel
@@ -37,6 +37,11 @@ constraint_value(
 )
 
 constraint_value(
+    name = "glibc_2_31",
+    constraint_setting = ":libc",
+)
+
+constraint_value(
     name = "cortexa7t2hf-neon-poky",
     constraint_setting = "@platforms//cpu",
 )

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -58,7 +58,7 @@ def aarch64_sysroot():
     maybe(
         http_archive,
         name = "aarch64-sysroot",
-        sha256 = "3ca6e598e6f58b2f9dbba2ecb335ba2bf552988bcfeda7677f9ce1291f03028f",
+        sha256 = "9bd27c7ec6aa4bd3d4df60cd04228669bcf366aec32d4b4dc7b504de2f63121e",
         build_file_content = """
 filegroup(
     name = "aarch64-sysroot",
@@ -66,7 +66,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-        url = "https://github.com/swift-nav/swift-toolchains/releases/download/aarch64-sysroot-v1/debian_bullseye_arm64_sysroot.tar.xz",
+        url = "https://github.com/swift-nav/swift-toolchains/releases/download/bullseye-aarch64-sysroot-v1/debian_bullseye_aarch64_sysroot.tar.xz",
     )
 
 def register_swift_cc_toolchains():

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -54,6 +54,21 @@ def swift_cc_toolchain():
         sha256 = "61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5",
     )
 
+def aarch64_sysroot():
+    maybe(
+        http_archive,
+        name = "aarch64-sysroot",
+        sha256 = "3ca6e598e6f58b2f9dbba2ecb335ba2bf552988bcfeda7677f9ce1291f03028f",
+        build_file_content = """
+filegroup(
+    name = "aarch64-sysroot",
+    srcs = glob(["*/**"]),
+    visibility = ["//visibility:public"],
+)
+    """,
+        url = "https://github.com/swift-nav/swift-toolchains/releases/download/aarch64-sysroot-v1/debian_bullseye_arm64_sysroot.tar.xz",
+    )
+
 def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -58,6 +58,7 @@ def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux")
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-x86_64-aarch64-linux")
 
 def aarch64_linux_musl_toolchain():
     http_archive(

--- a/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
@@ -11,6 +11,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("//cc/toolchains/llvm:target_triplets.bzl", "AARCH64_DARWIN")
 
 filegroup(
     name = "wrappers",
@@ -98,11 +99,11 @@ cc_toolchain_config(
         "%sysroot%/usr/include",
         "%sysroot%/System/Library/Frameworks",
     ],
-    host_system_name = "darwin-aarch64",
+    host_system_name = AARCH64_DARWIN,
     is_darwin = True,
     target_cpu = "darwin",
     target_libc = "macosx",
-    target_system_name = "aarch64-apple-macosx",
+    target_system_name = AARCH64_DARWIN,
     tool_paths = {
         "ar": "/usr/bin/libtool",
         "cpp": "wrappers/clang-cpp",

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -12,6 +12,7 @@ load(
     "@bazel_tools//tools/cpp:unix_cc_toolchain_config.bzl",
     unix_cc_toolchain_config = "cc_toolchain_config",
 )
+load("//cc/toolchains/llvm:target_triplets.bzl", "is_target_triplet")
 
 def cc_toolchain_config(
         name,
@@ -28,6 +29,12 @@ def cc_toolchain_config(
         target_system_name,
         builtin_sysroot = None,
         is_darwin = False):
+    if not is_target_triplet(host_system_name):
+        fail(host_system_name + " is not a target tripplet")
+
+    if not is_target_triplet(target_system_name):
+        fail(target_system_name + " is not a target tripplet")
+
     cross_compile = host_system_name != target_system_name
 
     # Default compiler flags:

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -83,10 +83,6 @@ def cc_toolchain_config(
         "-no-canonical-prefixes",
     ]
 
-    link_flags.extend([
-        "-L{}/usr/lib/aarch64-linux-gnu".format(builtin_sysroot),
-    ])
-
     # Similar to link_flags, but placed later in the command line such that
     # unused symbols are not stripped.
     link_libs = []

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -83,6 +83,10 @@ def cc_toolchain_config(
         "-no-canonical-prefixes",
     ]
 
+    link_flags.extend([
+        "-L{}/usr/lib/aarch64-linux-gnu".format(builtin_sysroot),
+    ])
+
     # Similar to link_flags, but placed later in the command line such that
     # unused symbols are not stripped.
     link_libs = []

--- a/cc/toolchains/llvm/target_triplets.bzl
+++ b/cc/toolchains/llvm/target_triplets.bzl
@@ -1,0 +1,10 @@
+X86_64_LINUX = "x86_64-unknown-linux-gnu"
+AARCH64_LINUX = "aarch64-unknown-linux-gnu"
+X86_64_DARWIN = "x86_64-apple-macosx"
+AARCH64_DARWIN = "aarch64-apple-macosx"
+
+def is_target_triplet(target):
+    return target != X86_64_LINUX or \
+           target != AARCH64_LINUX or \
+           target != X86_64_DARWIN or \
+           target != AARCH64_DARWIN

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -1,0 +1,157 @@
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:ar",
+    ],
+)
+
+filegroup(
+    name = "as_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:as",
+    ],
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:clang",
+        "@x86_64-linux-llvm//:include",
+    ],
+)
+
+filegroup(
+    name = "dwp_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:dwp",
+    ],
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:ar",
+        "@x86_64-linux-llvm//:clang",
+        "@x86_64-linux-llvm//:ld",
+        "@x86_64-linux-llvm//:lib",
+    ],
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        ":wrappers",
+        "@sysroot",
+        "@x86_64-linux-llvm//:objcopy",
+    ],
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        ":wrappers",
+        "@x86_64-linux-llvm//:strip",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        "linker_files",
+        ":compiler_files",
+        "@sysroot",
+        "@x86_64-linux-llvm//:bin",
+    ],
+)
+
+cc_toolchain_config(
+    name = "local-x86_64-aarch64-linux",
+    abi_libc_version = "glibc_unknown",
+    abi_version = "clang",
+    builtin_sysroot = "external/sysroot",
+    compiler = "clang",
+    cxx_builtin_include_directories = [
+        "%sysroot%/usr/lib/gcc/aarch64-linux-gnu/10/include",
+        "%sysroot%/usr/include",
+    ],
+    host_system_name = "linux-x86_64",
+    target_cpu = "k8",
+    target_libc = "glibc_unknown",
+    target_system_name = "aarch64-unknown-linux-gnu",
+    tool_paths = {
+        "ar": "wrappers/llvm-ar",
+        "cpp": "wrappers/clang-cpp",
+        "gcc": "wrappers/clang",
+        "gcov": "wrappers/llvm-profdata",
+        "llvm-cov": "wrappers/llvm-cov",
+        "llvm-profdata": "wrappers/llvm-profdata",
+        "ld": "wrappers/ld.ldd",
+        "nm": "wrappers/llvm-nm",
+        "objcopy": "wrappers/llvm-objcopy",
+        "objdump": "wrappers/llvm-objdump",
+        "strip": "wrappers/llvm-strip",
+    },
+    toolchain_identifier = "clang-x86_64-linux",
+    toolchain_path_prefix = "external/x86_64-linux-llvm",
+)
+
+cc_toolchain(
+    name = "cc-clang-x86_64-aarch64-linux",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    as_files = ":as_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":dwp_files",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    toolchain_config = ":local-x86_64-aarch64-linux",
+)
+
+toolchain(
+    name = "cc-toolchain-x86_64-aarch64-linux",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//cc/constraints:llvm_toolchain",
+    ],
+    target_settings = None,
+    toolchain = ":cc-clang-x86_64-aarch64-linux",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -24,7 +24,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:ar",
     ],
 )
@@ -33,7 +33,7 @@ filegroup(
     name = "as_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:as",
     ],
 )
@@ -42,7 +42,7 @@ filegroup(
     name = "compiler_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:clang",
         "@x86_64-linux-llvm//:include",
     ],
@@ -52,7 +52,7 @@ filegroup(
     name = "dwp_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:dwp",
     ],
 )
@@ -61,7 +61,7 @@ filegroup(
     name = "linker_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:ar",
         "@x86_64-linux-llvm//:clang",
         "@x86_64-linux-llvm//:ld",
@@ -73,7 +73,7 @@ filegroup(
     name = "objcopy_files",
     srcs = [
         ":wrappers",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:objcopy",
     ],
 )
@@ -91,7 +91,7 @@ filegroup(
     srcs = [
         "linker_files",
         ":compiler_files",
-        "@sysroot",
+        "@aarch64-sysroot",
         "@x86_64-linux-llvm//:bin",
     ],
 )
@@ -100,10 +100,9 @@ cc_toolchain_config(
     name = "local-x86_64-aarch64-linux",
     abi_libc_version = "glibc_unknown",
     abi_version = "clang",
-    builtin_sysroot = "external/sysroot",
+    builtin_sysroot = "external/aarch64-sysroot",
     compiler = "clang",
     cxx_builtin_include_directories = [
-        "%sysroot%/usr/lib/gcc/aarch64-linux-gnu/10/include",
         "%sysroot%/usr/include",
     ],
     host_system_name = "linux-x86_64",

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -11,6 +11,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("//cc/toolchains/llvm:target_triplets.bzl", "AARCH64_LINUX", "X86_64_LINUX")
 
 filegroup(
     name = "wrappers",
@@ -105,10 +106,10 @@ cc_toolchain_config(
     cxx_builtin_include_directories = [
         "%sysroot%/usr/include",
     ],
-    host_system_name = "linux-x86_64",
+    host_system_name = X86_64_LINUX,
     target_cpu = "k8",
     target_libc = "glibc_unknown",
-    target_system_name = "aarch64-unknown-linux-gnu",
+    target_system_name = AARCH64_LINUX,
     tool_paths = {
         "ar": "wrappers/llvm-ar",
         "cpp": "wrappers/clang-cpp",
@@ -146,8 +147,9 @@ toolchain(
         "@platforms//os:linux",
     ],
     target_compatible_with = [
-        "@platforms//cpu:aarch64",
         "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        "//cc/constraints:glibc_2_31",
         "//cc/constraints:llvm_toolchain",
     ],
     target_settings = None,

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/clang
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/clang
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/clang-cpp
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/clang-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/ld.lld
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/ld.lld
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-ar
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-cov
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-cov
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-nm
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-objcopy
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-objcopy
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-objdump
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-profdata
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-profdata
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-strip
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/llvm-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+# Locates the actual tool paths relative to the location this script is 
+# executed from.
+#
+# This is necessary because we download the toolchain using
+# http_archive, which bazel places in _execroot_/external/_repo_name_.
+#
+# Unfortunately we cannot provide this location as the argument of tool_path
+# when configuring the toolchain, because tool_path only takes a relative path.
+#
+# This is the fairly common workaround to handle this.
+#
+# TODO: [BUILD-549] - Remove need for wrapper files
+#
+# Recent versions of Bazel may have introduced a mechanism that removes
+# the need for this workaround: https://github.com/bazelbuild/bazel/issues/7746
+
+set -e
+
+# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+  set -x
+fi
+
+tool_name=$(basename "${BASH_SOURCE[0]}")
+toolchain_bindir=external/x86_64-linux-llvm/bin
+
+if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  # This branch exists because some users of the toolchain,
+  # namely rules_foreign_cc, will change CWD and call $CC (this script)
+  # with its absolute path.
+  #
+  # To deal with this we find the tool relative to this script, which is at
+  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  #
+  # If the wrapper is relocated then this line needs to be adjusted.
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
+  exec "${tool}" "${@}"
+else
+  >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
+  exit 5
+fi
+

--- a/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
@@ -11,6 +11,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("//cc/toolchains/llvm:target_triplets.bzl", "X86_64_DARWIN")
 
 filegroup(
     name = "wrappers",
@@ -99,11 +100,11 @@ cc_toolchain_config(
         "%sysroot%/usr/include",
         "%sysroot%/System/Library/Frameworks",
     ],
-    host_system_name = "darwin-x86_64",
+    host_system_name = X86_64_DARWIN,
     is_darwin = True,
     target_cpu = "darwin",
     target_libc = "macosx",
-    target_system_name = "x86_64-apple-macosx",
+    target_system_name = X86_64_DARWIN,
     tool_paths = {
         "ar": "/usr/bin/libtool",
         "cpp": "wrappers/clang-cpp",

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -11,6 +11,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("//cc/toolchains/llvm:target_triplets.bzl", "X86_64_LINUX")
 
 filegroup(
     name = "wrappers",
@@ -99,10 +100,10 @@ cc_toolchain_config(
         "/usr/include",
         "/usr/local/include",
     ],
-    host_system_name = "linux-x86_64",
+    host_system_name = X86_64_LINUX,
     target_cpu = "k8",
     target_libc = "glibc_unknown",
-    target_system_name = "x86_64-unknown-linux-gnu",
+    target_system_name = X86_64_LINUX,
     tool_paths = {
         "ar": "wrappers/llvm-ar",
         "cpp": "wrappers/clang-cpp",

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -101,3 +101,11 @@ platform(
         "//cc/constraints:yocto_generic_toolchain",
     ],
 )
+
+platform(
+    name = "aarch64_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -103,9 +103,10 @@ platform(
 )
 
 platform(
-    name = "aarch64_linux",
+    name = "aarch64_bullseye",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
+        "//cc/constraints:glibc_2_31",
     ],
 )

--- a/third_party/openssl.BUILD
+++ b/third_party/openssl.BUILD
@@ -24,9 +24,17 @@ filegroup(
 
 configure_make(
     name = "openssl",
-    configure_command = "config",
+    configure_command = "Configure",
     configure_in_place = True,
-    configure_options = [
+    configure_options = select(
+        {
+            "@bazel_tools//src/conditions:linux_x86_64": ["linux-x86_64"],
+            "@bazel_tools//src/conditions:linux_aarch64": ["linux-aarch64"],
+            "@bazel_tools//src/conditions:darwin_x86_64": ["darwin64-x86_64-cc"],
+            "@rules_swiftnav//platforms:aarch64_darwin": ["darwin64-arm64-cc"],
+        },
+        no_match_error = "Currently only aarch64-darwin, x86_64-darwin, x86_64-linux, and aarch64-linux are supported.",
+    ) + [
         "no-comp",
         "no-idea",
         "no-weak-ssl-ciphers",


### PR DESCRIPTION
Usage:
WORKSPACE.bazel
```
load("@rules_swiftnav//cc:repositories.bzl", "aarch64_sysroot", "register_swift_cc_toolchains", "swift_cc_toolchain")
aarch64_sysroot()
```

`bazel build --platforms=@rules_swiftnav//platforms:aarch64_bullseye //...`

This PR also adds support for cross-compilation for openssl.