### PR TITLE
Add aarch64_linux support for netcdf-c

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -8,13 +8,19 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
 config_setting(
     name = "aarch64_darwin",
     constraint_values = [
         "@platforms//cpu:aarch64",
         "@platforms//os:macos",
+    ],
+)
+
+config_setting(
+    name = "aarch64_linux",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
     ],
 )
 

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -15,7 +15,7 @@ netcdf-c@4.9.0
 load("@rules_swiftnav//tools:configure_file.bzl", "configure_file")
 load("@rules_swiftnav//third_party/netcdf-c:aarch64-darwin-config.bzl", "AARCH64_DARWIN_CONFIG")
 load("@rules_swiftnav//third_party/netcdf-c:x86_64-darwin-config.bzl", "X86_64_DARWIN_CONFIG")
-load("@rules_swiftnav//third_party/netcdf-c:x86_64-linux-config.bzl", "X86_64_LINUX_CONFIG")
+load("@rules_swiftnav//third_party/netcdf-c:linux-config.bzl", "LINUX_CONFIG")
 load("@rules_swiftnav//third_party/netcdf-c:attr.bzl", "attr")
 load("@rules_swiftnav//third_party/netcdf-c:ncx.bzl", "ncx")
 load("@rules_swiftnav//third_party/netcdf-c:putget.bzl", "putget")
@@ -133,10 +133,9 @@ genrule(
     cmd = select(
         {
             "@rules_swiftnav//platforms:aarch64_darwin": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
-            # reuse X86_64_LINUX_CONFIG for aarch64_linux
-            "@rules_swiftnav//platforms:aarch64_linux": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
+            "@rules_swiftnav//platforms:aarch64_linux": "cat <<'EOF' > $@ {}EOF".format(LINUX_CONFIG),
             "@bazel_tools//src/conditions:darwin_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_DARWIN_CONFIG),
-            "@bazel_tools//src/conditions:linux_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
+            "@bazel_tools//src/conditions:linux_x86_64": "cat <<'EOF' > $@ {}EOF".format(LINUX_CONFIG),
         },
         no_match_error = "Currently only aarch64-darwin, aarch64-linux, x86_64-darwin and x86_64-linux are supported.",
     ),

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -133,10 +133,12 @@ genrule(
     cmd = select(
         {
             "@rules_swiftnav//platforms:aarch64_darwin": "cat <<'EOF' > $@ {}EOF".format(AARCH64_DARWIN_CONFIG),
+            # reuse X86_64_LINUX_CONFIG for aarch64_linux
+            "@rules_swiftnav//platforms:aarch64_linux": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
             "@bazel_tools//src/conditions:darwin_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_DARWIN_CONFIG),
             "@bazel_tools//src/conditions:linux_x86_64": "cat <<'EOF' > $@ {}EOF".format(X86_64_LINUX_CONFIG),
         },
-        no_match_error = "Currently only aarch64-darwin, x86_64-darwin, and x86_64-linux are supported.",
+        no_match_error = "Currently only aarch64-darwin, aarch64-linux, x86_64-darwin and x86_64-linux are supported.",
     ),
 )
 

--- a/third_party/netcdf-c/linux-config.bzl
+++ b/third_party/netcdf-c/linux-config.bzl
@@ -1,4 +1,4 @@
-X86_64_LINUX_CONFIG = r"""
+LINUX_CONFIG = r"""
 /*! \file
 
 Copyright 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,


### PR DESCRIPTION
I generated a config for aarch64_linux is the same as the one for x86_64_linux, so I just reused it.

# Testing
orion built just fine on my x84_64 machine with this commit