### PR TITLE
fix: enable clang-tidy on macos and suppress proto errors [BUILD-658]

### DIFF
--- a/clang_format/BUILD.bazel
+++ b/clang_format/BUILD.bazel
@@ -19,7 +19,7 @@ choose_clang_format(
 filegroup(
     name = "_clang_format_bin",
     srcs = select({
-        "@bazel_tools//src/conditions:darwin_arm64": ["@aarch64-darwin-llvm//:clang-format"],
+        "@rules_swiftnav//platforms:aarch64_darwin": ["@aarch64-darwin-llvm//:clang-format"],
         "@bazel_tools//src/conditions:darwin_x86_64": ["@x86_64-darwin-llvm//:clang-format"],
         "@bazel_tools//src/conditions:linux_x86_64": ["@x86_64-linux-llvm//:clang-format"],
         "//conditions:default": [":clang_format_bin"],

--- a/clang_tidy/BUILD.bazel
+++ b/clang_tidy/BUILD.bazel
@@ -30,7 +30,6 @@ filegroup(
     name = "clang_tidy_executable_default",
     srcs = select(
         {
-            "@rules_swiftnav//platforms:aarch64_darwin": ["@aarch64-darwin-llvm//:clang-tidy"],
             "@bazel_tools//src/conditions:darwin_x86_64": ["@x86_64-darwin-llvm//:clang-tidy"],
             "@bazel_tools//src/conditions:linux_x86_64": ["@x86_64-linux-llvm//:clang-tidy"],
             "//conditions:default": [":clang_tidy_bin"],

--- a/clang_tidy/BUILD.bazel
+++ b/clang_tidy/BUILD.bazel
@@ -7,7 +7,10 @@ choose_clang_tidy(
 
 sh_binary(
     name = "clang_tidy",
-    srcs = ["run_clang_tidy.sh"],
+    srcs = select({
+        "@platforms//os:macos": ["run_clang_tidy_macos.sh"],
+        "//conditions:default": ["run_clang_tidy.sh"],
+    }),
     data = [":clang_tidy_config"],
     visibility = ["//visibility:public"],
 )

--- a/clang_tidy/BUILD.bazel
+++ b/clang_tidy/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
     name = "clang_tidy_executable_default",
     srcs = select(
         {
+            "@rules_swiftnav//platforms:aarch64_darwin": ["@aarch64-darwin-llvm//:clang-tidy"],
             "@bazel_tools//src/conditions:darwin_x86_64": ["@x86_64-darwin-llvm//:clang-tidy"],
             "@bazel_tools//src/conditions:linux_x86_64": ["@x86_64-linux-llvm//:clang-tidy"],
             "//conditions:default": [":clang_tidy_bin"],

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -33,8 +33,6 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
     # start args passed to the compiler
     args.add("--")
 
-    print(flags)
-
     # add args specified by the toolchain, on the command line and rule copts
     args.add_all(flags)
 
@@ -52,7 +50,7 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
     for i in _flatten([compilation_context.includes.to_list() for compilation_context in compilation_contexts]):
         if "pb" in i:
             args.add("-isystem" + i)
-        else if "gflags" in i:
+        elif "gflags" in i:
             args.add("-isystem" + i)
         else:
             args.add("-I" + i)

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -48,6 +48,8 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
         args.add("-F" + i)
 
     for i in _flatten([compilation_context.includes.to_list() for compilation_context in compilation_contexts]):
+        if "pb" in i:
+            args.add("-isystem" + i)
         if "gflags" in i:
             args.add("-isystem" + i)
         else:

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -52,7 +52,7 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
     for i in _flatten([compilation_context.includes.to_list() for compilation_context in compilation_contexts]):
         if "pb" in i:
             args.add("-isystem" + i)
-        if "gflags" in i:
+        else if "gflags" in i:
             args.add("-isystem" + i)
         else:
             args.add("-I" + i)

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -33,6 +33,8 @@ def _run_tidy(ctx, wrapper, exe, additional_deps, config, flags, compilation_con
     # start args passed to the compiler
     args.add("--")
 
+    print(flags)
+
     # add args specified by the toolchain, on the command line and rule copts
     args.add_all(flags)
 

--- a/clang_tidy/run_clang_tidy_macos.sh
+++ b/clang_tidy/run_clang_tidy_macos.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+# Usage: run_clang_tidy <CONFIG> <OUTPUT> [ARGS...]
+set -ue
+
+# Necessary for clang-tidy to find system headers on mac
+export SDKROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+
+CLANG_TIDY_BIN=$1
+shift
+
+CONFIG=$1
+shift
+
+OUTPUT=$1
+shift
+
+# .clang-tidy config file has to be placed in the current working directory
+if [ ! -f ".clang-tidy" ]; then
+    ln -s $CONFIG .clang-tidy
+fi
+
+# clang-tidy doesn't create a patchfile if there are no errors.
+# make sure the output exists, and empty if there are no errors,
+# so the build system will not be confused.
+touch $OUTPUT
+truncate -s 0 $OUTPUT
+
+"${CLANG_TIDY_BIN}" "$@"
+
+test ! -s $OUTPUT


### PR DESCRIPTION
Two fixes:

Sets the `SDKROOT` env var when we call clang-tidy on macos. Without this clang-tidy is unable to
find the system headers.

Adds generated proto headers to `-isystem` includes list instead of `-I` includes when running the linter.
This was causing failures whenever proto headers were present in the build.

Tested: https://github.com/swift-nav/orion-engine/pull/6311