### PR TITLE
add tags=["manual"] to image_tag rules

### DIFF
--- a/image/defs.bzl
+++ b/image/defs.bzl
@@ -37,6 +37,7 @@ def image_tag(name, tag):
         name = name,
         outs = ["{}.txt".format(name)],
         cmd = "echo {} > $@".format(tag),
+        tags = ["manual"]
     )
 
 def image_stamp_tag(name, var):
@@ -53,4 +54,5 @@ def image_stamp_tag(name, var):
         # `(?<=A)B` in regex is a positive lookbehind - finds expression B that's preceded with A
         cmd = "cat bazel-out/stable-status.txt | grep -Po '(?<={}\\s).*' > $@".format(var),
         stamp = True,
+        tags = ["manual"]
     )

--- a/image/defs.bzl
+++ b/image/defs.bzl
@@ -17,6 +17,7 @@ def swift_image_index(name, image, platforms, **kwargs):
         name = transition_name,
         image = image,
         platforms = platforms,
+        tags = ["manual"],
     )
 
     oci_image_index(

--- a/image/defs.bzl
+++ b/image/defs.bzl
@@ -37,7 +37,7 @@ def image_tag(name, tag):
         name = name,
         outs = ["{}.txt".format(name)],
         cmd = "echo {} > $@".format(tag),
-        tags = ["manual"]
+        tags = ["manual"],
     )
 
 def image_stamp_tag(name, var):
@@ -54,5 +54,5 @@ def image_stamp_tag(name, var):
         # `(?<=A)B` in regex is a positive lookbehind - finds expression B that's preceded with A
         cmd = "cat bazel-out/stable-status.txt | grep -Po '(?<={}\\s).*' > $@".format(var),
         stamp = True,
-        tags = ["manual"]
+        tags = ["manual"],
     )


### PR DESCRIPTION
without this change `image_stamp_tag` is built by default, even when stamping is not enabled and it cannot find the `stable-status.txt` file