### PR TITLE
cc: toolchain: Add x86_64 sysroot [CLARM-39]

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -94,3 +94,15 @@ config_setting(
     flag_values = {":cxx_standard": "23"},
     visibility = ["//visibility:public"],
 )
+
+bool_flag(
+    name = "enable_sysroot",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_enable_sysroot",
+    flag_values = {":enable_sysroot": "true"},
+    visibility = ["//visibility:public"],
+)

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -73,7 +73,7 @@ def x86_64_sysroot():
     maybe(
         http_archive,
         name = "x86_64-sysroot",
-        # sha256 = "9bd27c7ec6aa4bd3d4df60cd04228669bcf366aec32d4b4dc7b504de2f63121e",
+        sha256 = "a19dd3fe4a61d0e1a18f197be1b0c9a2a06b1deabaff2f1479cfcc2cb0df85d1",
         build_file_content = """
 filegroup(
     name = "x86_64-sysroot",

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -69,6 +69,21 @@ filegroup(
         url = "https://github.com/swift-nav/swift-toolchains/releases/download/bullseye-aarch64-sysroot-v1/debian_bullseye_aarch64_sysroot.tar.xz",
     )
 
+def x86_64_sysroot():
+    maybe(
+        http_archive,
+        name = "x86_64-sysroot",
+        # sha256 = "9bd27c7ec6aa4bd3d4df60cd04228669bcf366aec32d4b4dc7b504de2f63121e",
+        build_file_content = """
+filegroup(
+    name = "x86_64-sysroot",
+    srcs = glob(["*/**"]),
+    visibility = ["//visibility:public"],
+)
+    """,
+        url = "https://github.com/swift-nav/swift-toolchains/releases/download/bullseye-x86_64-sysroot-v1/debian_bullseye_x86_64_sysroot.tar.xz",
+    )
+
 def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -35,7 +35,7 @@ def cc_toolchain_config(
     if not is_target_triplet(target_system_name):
         fail(target_system_name + " is not a target tripplet")
 
-    cross_compile = host_system_name != target_system_name
+    use_bundled_libcpp = builtin_sysroot != None
 
     # Default compiler flags:
     compile_flags = [
@@ -82,7 +82,7 @@ def cc_toolchain_config(
         # The whole codebase should build with c++14
         "-std=c++14",
         # Use bundled libc++ for hermeticity if not cross compiling
-    ] + ["-stdlib=libstdc++"] if cross_compile else ["-stdlib=libc++"]
+    ] + ["-stdlib=libstdc++"] if use_bundled_libcpp else ["-stdlib=libc++"]
 
     link_flags = [
         "--target=" + target_system_name,
@@ -124,7 +124,7 @@ def cc_toolchain_config(
             "-ldl",
         ])
 
-        if cross_compile:
+        if use_bundled_libcpp:
             link_flags.extend([
                 # Use libstdc++ from the sysroot when cross compiling
                 "-l:libstdc++.a",

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -35,7 +35,7 @@ def cc_toolchain_config(
     if not is_target_triplet(target_system_name):
         fail(target_system_name + " is not a target tripplet")
 
-    use_bundled_libcpp = builtin_sysroot != None and not is_darwin
+    use_libstdcpp = builtin_sysroot != None and not is_darwin
 
     # Default compiler flags:
     compile_flags = [
@@ -82,7 +82,7 @@ def cc_toolchain_config(
         # The whole codebase should build with c++14
         "-std=c++14",
         # Use bundled libc++ for hermeticity if not cross compiling
-    ] + ["-stdlib=libstdc++"] if use_bundled_libcpp else ["-stdlib=libc++"]
+    ] + ["-stdlib=libstdc++"] if use_libstdcpp else ["-stdlib=libc++"]
 
     link_flags = [
         "--target=" + target_system_name,
@@ -124,7 +124,7 @@ def cc_toolchain_config(
             "-ldl",
         ])
 
-        if use_bundled_libcpp:
+        if use_libstdcpp:
             link_flags.extend([
                 # Use libstdc++ from the sysroot when cross compiling
                 "-l:libstdc++.a",

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -35,7 +35,7 @@ def cc_toolchain_config(
     if not is_target_triplet(target_system_name):
         fail(target_system_name + " is not a target tripplet")
 
-    use_bundled_libcpp = builtin_sysroot != None
+    use_bundled_libcpp = builtin_sysroot != None and not is_darwin
 
     # Default compiler flags:
     compile_flags = [

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -12,7 +12,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
 load("//cc/toolchains/llvm:target_triplets.bzl", "X86_64_LINUX")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 filegroup(
     name = "wrappers",

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -85,8 +85,10 @@ filegroup(
     srcs = [
         ":wrappers",
         "@x86_64-linux-llvm//:objcopy",
-        "@x86_64-sysroot",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -12,6 +12,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
 load("//cc/toolchains/llvm:target_triplets.bzl", "X86_64_LINUX")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 filegroup(
     name = "wrappers",
@@ -26,7 +27,10 @@ filegroup(
     srcs = [
         ":wrappers",
         "@x86_64-linux-llvm//:ar",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -34,7 +38,10 @@ filegroup(
     srcs = [
         ":wrappers",
         "@x86_64-linux-llvm//:as",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -43,7 +50,10 @@ filegroup(
         ":wrappers",
         "@x86_64-linux-llvm//:clang",
         "@x86_64-linux-llvm//:include",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -51,7 +61,10 @@ filegroup(
     srcs = [
         ":wrappers",
         "@x86_64-linux-llvm//:dwp",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -62,7 +75,10 @@ filegroup(
         "@x86_64-linux-llvm//:clang",
         "@x86_64-linux-llvm//:ld",
         "@x86_64-linux-llvm//:lib",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(
@@ -70,6 +86,7 @@ filegroup(
     srcs = [
         ":wrappers",
         "@x86_64-linux-llvm//:objcopy",
+        "@x86_64-sysroot",
     ],
 )
 
@@ -87,19 +104,29 @@ filegroup(
         "linker_files",
         ":compiler_files",
         "@x86_64-linux-llvm//:bin",
-    ],
+    ] + select({
+        "//cc:_enable_sysroot": ["@x86_64-sysroot"],
+        "//conditions:default": [],
+    }),
 )
 
 cc_toolchain_config(
     name = "local-x86_64-linux",
     abi_libc_version = "glibc_unknown",
     abi_version = "clang",
+    builtin_sysroot = select({
+        "//cc:_enable_sysroot": "external/x86_64-sysroot",
+        "//conditions:default": None,
+    }),
     compiler = "clang",
-    cxx_builtin_include_directories = [
-        "/include",
-        "/usr/include",
-        "/usr/local/include",
-    ],
+    cxx_builtin_include_directories = select({
+        "//cc:_enable_sysroot": ["%sysroot%/usr/include"],
+        "//conditions:default": [
+            "/include",
+            "/usr/include",
+            "/usr/local/include",
+        ],
+    }),
     host_system_name = X86_64_LINUX,
     target_cpu = "k8",
     target_libc = "glibc_unknown",


### PR DESCRIPTION
This PR adds ability to use x86_64 sysroot with llvm toolchain. Usage:
`bazel build //...  --@rules_swiftnav//cc:enable_sysroot=true`

**Related PR**
https://github.com/swift-nav/swift-toolchains/pull/19
