### PR TITLE
fix: standard library selection in toolchain

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -106,3 +106,15 @@ config_setting(
     flag_values = {":enable_sysroot": "true"},
     visibility = ["//visibility:public"],
 )
+
+bool_flag(
+    name = "use_libstdcpp",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_use_libstdcpp",
+    flag_values = {":use_libstdcpp": "true"},
+    visibility = ["//visibility:public"],
+)

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -36,7 +36,6 @@ def cc_toolchain_config(
         fail(target_system_name + " is not a target tripplet")
 
     is_cross_compile = host_system_name != target_system_name
-    print(is_cross_compile)
 
     # Default compiler flags:
     compile_flags = [
@@ -84,7 +83,8 @@ def cc_toolchain_config(
         "-std=c++14",
     ] + select({
         "//cc:_use_libstdcpp": ["-stdlib=libstdc++"],
-        "//conditions:default": ["-stdlib=libc++"] if not is_cross_compile else ["-stdlib=libstdc++"],
+        "//cc:_enable_sysroot": ["-stdlib=libstdc++"],
+        "//conditions:default": ["-stdlib=libstdc++"] if is_cross_compile else ["-stdlib=libc++"],
     })
 
     link_flags = [
@@ -215,7 +215,8 @@ def cc_toolchain_config(
         cxx_flags = cxx_flags,
         link_flags = link_flags + select({
             "//cc:_use_libstdcpp": link_libstdcpp,
-            "//conditions:default": link_libcpp if not is_cross_compile else link_libstdcpp,
+            "//cc:_enable_sysroot": link_libstdcpp,
+            "//conditions:default": link_libstdcpp if is_cross_compile else link_libcpp,
         }),
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -35,7 +35,8 @@ def cc_toolchain_config(
     if not is_target_triplet(target_system_name):
         fail(target_system_name + " is not a target tripplet")
 
-    use_libstdcpp = builtin_sysroot != None and not is_darwin
+    is_cross_compile = host_system_name != target_system_name
+    print(is_cross_compile)
 
     # Default compiler flags:
     compile_flags = [
@@ -81,14 +82,20 @@ def cc_toolchain_config(
     cxx_flags = [
         # The whole codebase should build with c++14
         "-std=c++14",
-        # Use bundled libc++ for hermeticity if not cross compiling
-    ] + ["-stdlib=libstdc++"] if use_libstdcpp else ["-stdlib=libc++"]
+    ] + select({
+        "//cc:_use_libstdcpp": ["-stdlib=libstdc++"],
+        "//conditions:default": ["-stdlib=libc++"] if not is_cross_compile else ["-stdlib=libstdc++"],
+    })
 
     link_flags = [
         "--target=" + target_system_name,
         "-lm",
         "-no-canonical-prefixes",
     ]
+
+    link_libcpp = []
+
+    link_libstdcpp = ["-l:libstdc++.a"]
 
     # Similar to link_flags, but placed later in the command line such that
     # unused symbols are not stripped.
@@ -124,20 +131,14 @@ def cc_toolchain_config(
             "-ldl",
         ])
 
-        if use_libstdcpp:
-            link_flags.extend([
-                # Use libstdc++ from the sysroot when cross compiling
-                "-l:libstdc++.a",
-            ])
-        else:
-            link_flags.extend([
-                # Below this line, assumes libc++ & lld
-                "-l:libc++.a",
-                "-l:libc++abi.a",
-                "-l:libunwind.a",
-                # Compiler runtime features.
-                "-rtlib=compiler-rt",
-            ])
+        link_libcpp.extend([
+            # Below this line, assumes libc++ & lld
+            "-l:libc++.a",
+            "-l:libc++abi.a",
+            "-l:libunwind.a",
+            # Compiler runtime features.
+            "-rtlib=compiler-rt",
+        ])
     else:
         # The comments below were copied directly from:
         # https://github.com/grailbio/bazel-toolchain/blob/795d76fd03e0b17c0961f0981a8512a00cba4fa2/toolchain/cc_toolchain_config.bzl#L202
@@ -212,7 +213,10 @@ def cc_toolchain_config(
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
-        link_flags = link_flags,
+        link_flags = link_flags + select({
+            "//cc:_use_libstdcpp": link_libstdcpp,
+            "//conditions:default": link_libcpp if not is_cross_compile else link_libstdcpp,
+        }),
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,
         unfiltered_compile_flags = unfiltered_compile_flags,


### PR DESCRIPTION
I noticed that in #92 we inadvertently made it so that the standard library that is selected will always be `libstdc++`

Here we detect if a builtin sysroot exists to decide whether to choose `libstdc++` or `libc++`: https://github.com/swift-nav/rules_swiftnav/blob/0775da82c00a9d505f7854960d1dfd0445292aa9/cc/toolchains/llvm/cc_toolchain_config.bzl#L38

The problem with this is that we pass a `select` type at the call-site:
https://github.com/swift-nav/rules_swiftnav/blob/0775da82c00a9d505f7854960d1dfd0445292aa9/cc/toolchains/llvm/x86_64-linux/BUILD.bazel#L118

select statements are not expanded in macros, so `builtin_sysroot != None` is always true.

# Design Notes

To fix I refactored the toolchain config so that the standard library compiler and linker options are set via select statements.

I also made it so that regardless of the config setting - if we're cross compiling, then `libstdc++` will be selected.

I also added an extra config setting `_use_libstdc++` so that libstdc++ can be used independently of a sysroot.

# Testing

- [x] linux x86_64 using libc++ (default)
- [x] linux x86_64 using libstdc++
- [x] linux x86_64 using sysroot (libstdc++)
- [x] linux x86_64 -> linux aarch64 using libstdc++
- [x] darwin x86_64

