### PR TITLE
feat: toolchain: add support for aws graviton [CLARM-42]

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -106,3 +106,15 @@ config_setting(
     flag_values = {":enable_sysroot": "true"},
     visibility = ["//visibility:public"],
 )
+
+bool_flag(
+    name = "use_libstdcpp",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_use_libstdcpp",
+    flag_values = {":use_libstdcpp": "true"},
+    visibility = ["//visibility:public"],
+)

--- a/cc/constraints/BUILD.bazel
+++ b/cc/constraints/BUILD.bazel
@@ -41,6 +41,18 @@ constraint_value(
     constraint_setting = ":libc",
 )
 
+constraint_setting(name = "graviton")
+
+constraint_value(
+    name = "graviton2",
+    constraint_setting = ":graviton",
+)
+
+constraint_value(
+    name = "graviton3",
+    constraint_setting = ":graviton",
+)
+
 constraint_value(
     name = "cortexa7t2hf-neon-poky",
     constraint_setting = "@platforms//cpu",

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -88,7 +88,8 @@ def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux")
-    native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-x86_64-aarch64-linux")
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton2")
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton3")
 
 def aarch64_linux_musl_toolchain():
     http_archive(

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -36,7 +36,6 @@ def cc_toolchain_config(
         fail(target_system_name + " is not a target tripplet")
 
     is_cross_compile = host_system_name != target_system_name
-    print(is_cross_compile)
 
     # Default compiler flags:
     compile_flags = [
@@ -84,7 +83,8 @@ def cc_toolchain_config(
         "-std=c++14",
     ] + select({
         "//cc:_use_libstdcpp": ["-stdlib=libstdc++"],
-        "//conditions:default": ["-stdlib=libc++"] if not is_cross_compile else ["-stdlib=libstdc++"],
+        "//cc:_enable_sysroot": ["-stdlib=libstdc++"],
+        "//conditions:default": ["-stdlib=libstdc++"] if is_cross_compile else ["-stdlib=libc++"],
     })
 
     link_flags = [
@@ -215,7 +215,8 @@ def cc_toolchain_config(
         cxx_flags = cxx_flags,
         link_flags = link_flags + select({
             "//cc:_use_libstdcpp": link_libstdcpp,
-            "//conditions:default": link_libcpp if not is_cross_compile else link_libstdcpp,
+            "//cc:_enable_sysroot": link_libstdcpp,
+            "//conditions:default": link_libstdcpp if is_cross_compile else link_libcpp,
         }),
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -35,7 +35,8 @@ def cc_toolchain_config(
     if not is_target_triplet(target_system_name):
         fail(target_system_name + " is not a target tripplet")
 
-    use_libstdcpp = builtin_sysroot != None and not is_darwin
+    is_cross_compile = host_system_name != target_system_name
+    print(is_cross_compile)
 
     # Default compiler flags:
     compile_flags = [
@@ -81,14 +82,20 @@ def cc_toolchain_config(
     cxx_flags = [
         # The whole codebase should build with c++14
         "-std=c++14",
-        # Use bundled libc++ for hermeticity if not cross compiling
-    ] + ["-stdlib=libstdc++"] if use_libstdcpp else ["-stdlib=libc++"]
+    ] + select({
+        "//cc:_use_libstdcpp": ["-stdlib=libstdc++"],
+        "//conditions:default": ["-stdlib=libc++"] if not is_cross_compile else ["-stdlib=libstdc++"],
+    })
 
     link_flags = [
         "--target=" + target_system_name,
         "-lm",
         "-no-canonical-prefixes",
     ]
+
+    link_libcpp = []
+
+    link_libstdcpp = ["-l:libstdc++.a"]
 
     # Similar to link_flags, but placed later in the command line such that
     # unused symbols are not stripped.
@@ -124,20 +131,14 @@ def cc_toolchain_config(
             "-ldl",
         ])
 
-        if use_libstdcpp:
-            link_flags.extend([
-                # Use libstdc++ from the sysroot when cross compiling
-                "-l:libstdc++.a",
-            ])
-        else:
-            link_flags.extend([
-                # Below this line, assumes libc++ & lld
-                "-l:libc++.a",
-                "-l:libc++abi.a",
-                "-l:libunwind.a",
-                # Compiler runtime features.
-                "-rtlib=compiler-rt",
-            ])
+        link_libcpp.extend([
+            # Below this line, assumes libc++ & lld
+            "-l:libc++.a",
+            "-l:libc++abi.a",
+            "-l:libunwind.a",
+            # Compiler runtime features.
+            "-rtlib=compiler-rt",
+        ])
     else:
         # The comments below were copied directly from:
         # https://github.com/grailbio/bazel-toolchain/blob/795d76fd03e0b17c0961f0981a8512a00cba4fa2/toolchain/cc_toolchain_config.bzl#L202
@@ -212,7 +213,10 @@ def cc_toolchain_config(
         dbg_compile_flags = dbg_compile_flags,
         opt_compile_flags = opt_compile_flags,
         cxx_flags = cxx_flags,
-        link_flags = link_flags,
+        link_flags = link_flags + select({
+            "//cc:_use_libstdcpp": link_libstdcpp,
+            "//conditions:default": link_libcpp if not is_cross_compile else link_libstdcpp,
+        }),
         link_libs = link_libs,
         opt_link_flags = opt_link_flags,
         unfiltered_compile_flags = unfiltered_compile_flags,

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -28,6 +28,7 @@ def cc_toolchain_config(
         tool_paths,
         target_system_name,
         builtin_sysroot = None,
+        extra_copts = [],
         is_darwin = False):
     if not is_target_triplet(host_system_name):
         fail(host_system_name + " is not a target tripplet")
@@ -55,7 +56,7 @@ def cc_toolchain_config(
         "-Wall",
         "-Wthread-safety",
         "-Wself-assign",
-    ]
+    ] + extra_copts
 
     # -fstandalone-debug disables options that optimize
     # the size of the debug info.

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -106,6 +106,10 @@ cc_toolchain_config(
     cxx_builtin_include_directories = [
         "%sysroot%/usr/include",
     ],
+    extra_copts = select({
+        "//cc/constraints:graviton2": ["-mcpu=neoverse-n1"],
+        "//cc/constraints:graviton3": ["-mcpu=neoverse-512tvb"],
+    }),
     host_system_name = X86_64_LINUX,
     target_cpu = "k8",
     target_libc = "glibc_unknown",
@@ -125,10 +129,6 @@ cc_toolchain_config(
     },
     toolchain_identifier = "clang-x86_64-linux",
     toolchain_path_prefix = "external/x86_64-linux-llvm",
-    extra_copts = select({
-        "//cc/constraints:graviton2": ["-mcpu=neoverse-n1"],
-        "//cc/constraints:graviton3": ["-mcpu=neoverse-512tvb"],
-    }),
 )
 
 cc_toolchain(

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -125,6 +125,10 @@ cc_toolchain_config(
     },
     toolchain_identifier = "clang-x86_64-linux",
     toolchain_path_prefix = "external/x86_64-linux-llvm",
+    extra_copts = select({
+        "//cc/constraints:graviton2": ["-mcpu=neoverse-n1"],
+        "//cc/constraints:graviton3": ["-mcpu=neoverse-512tvb"],
+    }),
 )
 
 cc_toolchain(
@@ -141,7 +145,7 @@ cc_toolchain(
 )
 
 toolchain(
-    name = "cc-toolchain-x86_64-aarch64-linux",
+    name = "cc-toolchain-aarch64-bullseye-graviton2",
     exec_compatible_with = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
@@ -150,6 +154,25 @@ toolchain(
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
         "//cc/constraints:glibc_2_31",
+        "//cc/constraints:graviton2",
+        "//cc/constraints:llvm_toolchain",
+    ],
+    target_settings = None,
+    toolchain = ":cc-clang-x86_64-aarch64-linux",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+toolchain(
+    name = "cc-toolchain-aarch64-bullseye-graviton3",
+    exec_compatible_with = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        "//cc/constraints:glibc_2_31",
+        "//cc/constraints:graviton3",
         "//cc/constraints:llvm_toolchain",
     ],
     target_settings = None,

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -131,10 +131,22 @@ platform(
 )
 
 platform(
-    name = "aarch64_bullseye",
+    name = "aarch64_bullseye_graviton2",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
+        "//cc/constraints:graviton2",
+        "//cc/constraints:glibc_2_31",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "aarch64_bullseye_graviton3",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        "//cc/constraints:graviton3",
         "//cc/constraints:glibc_2_31",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Adds support for building for aws graviton2 and graviton3

# Usage
`bazel build --platforms=@rules_swiftnav//platforms:aarch64_bullseye_graviton2`
`bazel build --platforms=@rules_swiftnav//platforms:aarch64_bullseye_graviton3`

# Design Notes

I decided to implement two toolchains corresponding to two platforms for graviton2 and graviton3 respectively. I think this is the more "correct" way to do it. They share as much config as possible.

This also makes it more ergonomic to build mutli-arch images in a single invocation:
`bazel build //:multi_arch_image`

Whether a g2 or g3 compatible image is built is specified in the `BUILD.bazel` file. See related PR

# Related PR
- https://github.com/swift-nav/orion/pull/5937