### PR TITLE
feat: add support for gcc_arm_embedded on mac [BUILD-722]

### DIFF
--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -142,7 +142,7 @@ def gcc_arm_embedded_toolchain():
         name = "darwin_gcc_arm_embedded_toolchain",
         build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
-        url = DARWIN_LINUX_GCC_ARM_EMBEDDED,
+        url = DARWIN_GCC_ARM_EMBEDDED,
     )
 
 def register_gcc_arm_embedded_toolchain():

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -24,7 +24,9 @@ ARM_LINUX_MUSLEABIHF = "https://github.com/swift-nav/swift-toolchains/releases/d
 
 X86_64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-cross-11.2.0/x86_64-linux-musl-cross.tar.gz"
 
-GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
+DARWIN_GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-mac.tar.bz2"
+
+X86_64_LINUX_GCC_ARM_EMBEDDED = "https://github.com/swift-nav/swift-toolchains/releases/download/gcc-arm-none-eabi-10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
 
 def swift_cc_toolchain():
     maybe(
@@ -129,11 +131,18 @@ def register_x86_64_linux_musl_toolchain():
 
 def gcc_arm_embedded_toolchain():
     http_archive(
-        name = "gcc_arm_embedded_toolchain",
+        name = "x86_64_linux_gcc_arm_embedded_toolchain",
+        build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
+        strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
+        url = X86_64_LINUX_GCC_ARM_EMBEDDED,
+    )
+
+    http_archive(
+        name = "darwin_gcc_arm_embedded_toolchain",
         build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
         sha256 = "97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
-        url = GCC_ARM_EMBEDDED,
+        url = X86_64_LINUX_GCC_ARM_EMBEDDED,
     )
 
 def register_gcc_arm_embedded_toolchain():

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -133,6 +133,7 @@ def gcc_arm_embedded_toolchain():
     http_archive(
         name = "x86_64_linux_gcc_arm_embedded_toolchain",
         build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
+        sha256 = "97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
         url = X86_64_LINUX_GCC_ARM_EMBEDDED,
     )
@@ -140,9 +141,8 @@ def gcc_arm_embedded_toolchain():
     http_archive(
         name = "darwin_gcc_arm_embedded_toolchain",
         build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
-        sha256 = "97dbb4f019ad1650b732faffcc881689cedc14e2b7ee863d390e0a41ef16c9a3",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
-        url = X86_64_LINUX_GCC_ARM_EMBEDDED,
+        url = DARWIN_LINUX_GCC_ARM_EMBEDDED,
     )
 
 def register_gcc_arm_embedded_toolchain():

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -141,6 +141,7 @@ def gcc_arm_embedded_toolchain():
     http_archive(
         name = "darwin_gcc_arm_embedded_toolchain",
         build_file = "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain.BUILD",
+        sha256 = "fb613dacb25149f140f73fe9ff6c380bb43328e6bf813473986e9127e2bc283b",
         strip_prefix = "gcc-arm-none-eabi-10.3-2021.10",
         url = DARWIN_GCC_ARM_EMBEDDED,
     )

--- a/cc/toolchains/gcc_arm_embedded/config.bzl
+++ b/cc/toolchains/gcc_arm_embedded/config.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path", "with_feature_set")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 def _impl(ctx):
@@ -55,24 +55,28 @@ def _impl(ctx):
         ),
     ]
 
+    all_compile_actions = [
+        ACTION_NAMES.assemble,
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.clif_match,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.lto_backend,
+        ACTION_NAMES.preprocess_assemble,
+    ]
+
+    opt_feature = feature(name = "opt")
+
     features = [
         feature(
             name = "default_compile_actions",
             enabled = True,
             flag_sets = [
                 flag_set(
-                    actions = [
-                        ACTION_NAMES.assemble,
-                        ACTION_NAMES.c_compile,
-                        ACTION_NAMES.cpp_compile,
-                        ACTION_NAMES.cpp_header_parsing,
-                        ACTION_NAMES.cpp_module_codegen,
-                        ACTION_NAMES.cpp_module_compile,
-                        ACTION_NAMES.clif_match,
-                        ACTION_NAMES.linkstamp_compile,
-                        ACTION_NAMES.lto_backend,
-                        ACTION_NAMES.preprocess_assemble,
-                    ],
+                    actions = all_compile_actions,
                     flag_groups = ([
                         flag_group(
                             flags = [
@@ -90,6 +94,15 @@ def _impl(ctx):
                             ] + ctx.attr.c_opts,
                         ),
                     ]),
+                ),
+                flag_set(
+                    actions = all_compile_actions,
+                    flag_groups = ([
+                        flag_group(
+                            flags = ["-O2", "-g"],
+                        ),
+                    ]),
+                    with_features = [with_feature_set(features = ["opt"])],
                 ),
             ],
         ),
@@ -132,6 +145,7 @@ def _impl(ctx):
                 ),
             ],
         ),
+        opt_feature,
     ]
 
     return cc_common.create_cc_toolchain_config_info(


### PR DESCRIPTION
Adds support for downloading gcc_arm_embedded that is compatible with macos

Also adds a release configuration to the gcc_arm_embedded compiler.

Testing:
- https://github.com/swift-nav/dual-xgps-firmware/pull/25