### PR TITLE
Do not run clang-format if no files are selected

### DIFF
--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -13,8 +13,8 @@ format_all() {
         cp $CLANG_FORMAT_CONFIG .
     fi
     git describe --tags --abbrev=0 --always \
-    | xargs -I % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cc' '*.hpp' \
-    | xargs $CLANG_FORMAT_BIN -i
+    | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cc' '*.hpp' \
+    | xargs -r $CLANG_FORMAT_BIN -i
 }
 
 check_file() {


### PR DESCRIPTION
Use the `-r` switch with xargs to avoid running clang-format if no files are provided.