### PR TITLE
cc: enable symbolized output in sanitizer builds [BUILD-723]

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -8,6 +8,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 exports_files(
@@ -105,6 +106,16 @@ config_setting(
     name = "_enable_symbolizer",
     flag_values = {":enable_symbolizer": "true"},
     visibility = ["//visibility:public"],
+)
+
+selects.config_setting_group(
+    name = "_enable_symbolizer_x86_64_linux",
+    match_all = [":_enable_symbolizer", "@platforms//os:linux"],
+)
+
+selects.config_setting_group(
+    name = "_enable_symbolizer_x86_64_darwin",
+    match_all = [":_enable_symbolizer", "@platforms//os:macos"],
 )
 
 bool_flag(

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -110,12 +110,18 @@ config_setting(
 
 selects.config_setting_group(
     name = "_enable_symbolizer_x86_64_linux",
-    match_all = [":_enable_symbolizer", "@platforms//os:linux"],
+    match_all = [
+        ":_enable_symbolizer",
+        "@platforms//os:linux",
+    ],
 )
 
 selects.config_setting_group(
     name = "_enable_symbolizer_x86_64_darwin",
-    match_all = [":_enable_symbolizer", "@platforms//os:macos"],
+    match_all = [
+        ":_enable_symbolizer",
+        "@platforms//os:macos",
+    ],
 )
 
 bool_flag(

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -109,21 +109,23 @@ config_setting(
 )
 
 selects.config_setting_group(
-    name = "_enable_symbolizer_x86_64_linux",
+    name = "enable_symbolizer_x86_64_linux",
     match_all = [
         ":_enable_symbolizer",
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
+    visibility = ["//visibility:public"],
 )
 
 selects.config_setting_group(
-    name = "_enable_symbolizer_x86_64_darwin",
+    name = "enable_symbolizer_x86_64_darwin",
     match_all = [
         ":_enable_symbolizer",
         "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
+    visibility = ["//visibility:public"],
 )
 
 bool_flag(

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -96,6 +96,18 @@ config_setting(
 )
 
 bool_flag(
+    name = "enable_symbolizer",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_enable_symbolizer",
+    flag_values = {":enable_symbolizer": "true"},
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
     name = "enable_sysroot",
     build_setting_default = False,
     visibility = ["//visibility:public"],

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -112,6 +112,7 @@ selects.config_setting_group(
     name = "_enable_symbolizer_x86_64_linux",
     match_all = [
         ":_enable_symbolizer",
+        "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
 )
@@ -120,6 +121,7 @@ selects.config_setting_group(
     name = "_enable_symbolizer_x86_64_darwin",
     match_all = [
         ":_enable_symbolizer",
+        "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
 )

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -591,7 +591,8 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()
     kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
         "//conditions:default": {},
     })
     kwargs["data"] = kwargs.get("data", []) + select({

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -103,15 +103,15 @@ def _symbolizer_env(val):
     return select({
         # The + operator is not supported on dict and select types so we need to be
         # clever here.
-        Label("//cc:_enable_symbolizer_x86_64_linux"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"}),
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"}),
+        Label("//cc:enable_symbolizer_x86_64_linux"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"}),
+        Label("//cc:enable_symbolizer_x86_64_darwin"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"}),
         "//conditions:default": {},
     })
 
 def _symbolizer_data():
     return select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): ["@x86_64-linux-llvm//:symbolizer"],
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): ["@x86_64-darwin-llvm//:symbolizer"],
+        Label("//cc:enable_symbolizer_x86_64_linux"): ["@x86_64-linux-llvm//:symbolizer"],
+        Label("//cc:enable_symbolizer_x86_64_darwin"): ["@x86_64-darwin-llvm//:symbolizer"],
         "//conditions:default": [],
     })
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -384,6 +384,17 @@ def swift_c_binary(**kwargs):
 
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
 
+    kwargs["env"] = select({
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+
+    kwargs["data"] = kwargs.get("data", []) + select({
+        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
+        "//conditions:default": [],
+    })
+
     native.cc_binary(**kwargs)
 
 def swift_cc_binary(**kwargs):
@@ -431,8 +442,14 @@ def swift_cc_binary(**kwargs):
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
 
     kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
         "//conditions:default": {},
+    })
+
+    kwargs["data"] = kwargs.get("data", []) + select({
+        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
+        "//conditions:default": [],
     })
 
     native.cc_binary(**kwargs)
@@ -473,6 +490,17 @@ def swift_c_tool(**kwargs):
     c_standard = _c_standard(extensions, standard)
 
     kwargs["copts"] = copts + c_standard + kwargs.get("copts", [])
+
+    kwargs["env"] = select({
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+
+    kwargs["data"] = kwargs.get("data", []) + select({
+        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
+        "//conditions:default": [],
+    })
 
     native.cc_binary(**kwargs)
 
@@ -515,6 +543,17 @@ def swift_cc_tool(**kwargs):
     cxxopts = _common_cxx_opts(exceptions, rtti, standard)
 
     kwargs["copts"] = copts + cxxopts + kwargs.get("copts", [])
+
+    kwargs["env"] = select({
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+
+    kwargs["data"] = kwargs.get("data", []) + select({
+        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
+        "//conditions:default": [],
+    })
 
     native.cc_binary(**kwargs)
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -99,6 +99,20 @@ def _create_hdrs(**kwargs):
         visibility = kwargs.get("visibility", ["//visibility:private"]),
     )
 
+def _symbolizer_env():
+    return select({
+        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+
+def _symbolizer_data():
+    select({
+        Label("//cc:_enable_symbolizer_x86_64_linux"): ["@x86_64-linux-llvm//:symbolizer"],
+        Label("//cc:_enable_symbolizer_x86_64_darwin"): ["@x86_64-darwin-llvm//:symbolizer"],
+        "//conditions:default": [],
+    })
+
 def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility = None):
     """Creates a cc_library stamped with non-hermetic build metadata.
 
@@ -382,18 +396,11 @@ def swift_c_binary(**kwargs):
 
     kwargs["copts"] = copts + c_standard + kwargs.get("copts", [])
 
+    kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
+
+    kwargs["env"] = kwargs.get("env", []) + _symbolizer_env()
+
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
-
-    kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
-        "//conditions:default": {},
-    })
-
-    kwargs["data"] = kwargs.get("data", []) + select({
-        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
-        "//conditions:default": [],
-    })
 
     native.cc_binary(**kwargs)
 
@@ -439,18 +446,11 @@ def swift_cc_binary(**kwargs):
 
     kwargs["copts"] = copts + cxxopts + kwargs.get("copts", [])
 
+    kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
+
+    kwargs["env"] = kwargs.get("env", []) + _symbolizer_env()
+
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
-
-    kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
-        "//conditions:default": {},
-    })
-
-    kwargs["data"] = kwargs.get("data", []) + select({
-        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
-        "//conditions:default": [],
-    })
 
     native.cc_binary(**kwargs)
 
@@ -491,16 +491,9 @@ def swift_c_tool(**kwargs):
 
     kwargs["copts"] = copts + c_standard + kwargs.get("copts", [])
 
-    kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
-        "//conditions:default": {},
-    })
+    kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
 
-    kwargs["data"] = kwargs.get("data", []) + select({
-        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
-        "//conditions:default": [],
-    })
+    kwargs["env"] = kwargs.get("env", []) + _symbolizer_env()
 
     native.cc_binary(**kwargs)
 
@@ -544,16 +537,9 @@ def swift_cc_tool(**kwargs):
 
     kwargs["copts"] = copts + cxxopts + kwargs.get("copts", [])
 
-    kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
-        "//conditions:default": {},
-    })
+    kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
 
-    kwargs["data"] = kwargs.get("data", []) + select({
-        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
-        "//conditions:default": [],
-    })
+    kwargs["env"] = kwargs.get("env", []) + _symbolizer_env()
 
     native.cc_binary(**kwargs)
 
@@ -625,18 +611,11 @@ def swift_cc_test(name, type, **kwargs):
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
+    kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
+    kwargs["env"] = kwargs.get("env", []) + _symbolizer_env()
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)
     kwargs["name"] = name
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()
-    kwargs["env"] = select({
-        Label("//cc:_enable_symbolizer_x86_64_linux"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
-        Label("//cc:_enable_symbolizer_x86_64_darwin"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
-        "//conditions:default": {},
-    })
-    kwargs["data"] = kwargs.get("data", []) + select({
-        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
-        "//conditions:default": [],
-    })
 
     native.cc_test(**kwargs)

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -430,6 +430,11 @@ def swift_cc_binary(**kwargs):
 
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
 
+    kwargs["env"] = select({
+        Label("//cc:_enable_symbolizer"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+
     native.cc_binary(**kwargs)
 
 def swift_c_tool(**kwargs):
@@ -585,4 +590,13 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["name"] = name
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()
+    kwargs["env"] = select({
+        Label("//cc:_enable_symbolizer"): {"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"},
+        "//conditions:default": {},
+    })
+    kwargs["data"] = kwargs.get("data", []) + select({
+        Label("//cc:_enable_symbolizer"): ["@x86_64-linux-llvm//:symbolizer"],
+        "//conditions:default": [],
+    })
+
     native.cc_test(**kwargs)


### PR DESCRIPTION
Enables properly symbolized sanitizer output with clang.

Clang requires the `llvm-symbolizer` tool to convert addresses to source locations (see: https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports).

It either needs to be on the path or set via the `ASAN_SYMBOLIZER_PATH` environment variable.

# Design Notes

We can use the `cc*` `env` attr and [make variable substitution](https://bazel.build/reference/be/make-variables#predefined_label_variables) to make this work hermetically under bazel.

Our custom built llvm distribution for apple silicon is currently missing the extra clang tools so this will only work on intel mac and linux for now.

# Testing

Test PR:
- https://github.com/swift-nav/orion-engine/pull/6680