### PR TITLE
Add zlib to dependencies of glib

### DIFF
--- a/third_party/gzip.BUILD
+++ b/third_party/gzip.BUILD
@@ -16,4 +16,7 @@ cc_library(
     name = "gzip",
     hdrs = glob(["include/**"]),
     includes = ["include"],
+    deps = [
+        "@zlib",
+    ],
 )


### PR DESCRIPTION
`zlib` headers can't be found on the aarch64 sysroot, adding as dependency.