### PR TITLE
feat: clang-format: add format_all variant [DIP-243]

### DIFF
--- a/clang_format/BUILD.bazel
+++ b/clang_format/BUILD.bazel
@@ -33,6 +33,23 @@ sh_binary(
         "run_clang_format.sh",
     ],
     args = [
+        "format_diff",
+        "$(location :_clang_format_bin)",
+        "$(location :clang_format_config)",
+    ],
+    data = [
+        ":_clang_format_bin",
+        ":clang_format_config",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "clang_format_all",
+    srcs = [
+        "run_clang_format.sh",
+    ],
+    args = [
         "format_all",
         "$(location :_clang_format_bin)",
         "$(location :clang_format_config)",

--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -12,6 +12,17 @@ format_all() {
         echo ".clang-format file not found. Bazel will copy the default .clang-format file."
         cp $CLANG_FORMAT_CONFIG .
     fi
+    git ls-files '*.[ch]' '*.cpp' '*.cc' '*.hpp' | xargs -r $CLANG_FORMAT_BIN -i
+}
+
+format_diff() {
+    CLANG_FORMAT_CONFIG=$(realpath $1)
+
+    cd $BUILD_WORKSPACE_DIRECTORY
+    if ! test -f .clang-format; then
+        echo ".clang-format file not found. Bazel will copy the default .clang-format file."
+        cp $CLANG_FORMAT_CONFIG .
+    fi
     git describe --tags --abbrev=0 --always \
     | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cc' '*.hpp' \
     | xargs -r $CLANG_FORMAT_BIN -i
@@ -34,7 +45,9 @@ ARG=$1
 CLANG_FORMAT_BIN=$(realpath $2)
 shift 2
 
-if [ "$ARG" == "format_all" ]; then
+if [ "$ARG" == "format_diff" ]; then
+    format_diff "$@"
+elif [ "$ARG" == "format_all" ]; then
     format_all "$@"
 elif [ "$ARG" == "check_file" ]; then
     check_file "$@"

--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -12,7 +12,8 @@ format_all() {
         echo ".clang-format file not found. Bazel will copy the default .clang-format file."
         cp $CLANG_FORMAT_CONFIG .
     fi
-    git ls-files '*.[ch]' '*.cpp' '*.cc' '*.hpp' | xargs -r $CLANG_FORMAT_BIN -i
+    git ls-files '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
+    | xargs -r $CLANG_FORMAT_BIN -i
 }
 
 format_diff() {
@@ -24,7 +25,7 @@ format_diff() {
         cp $CLANG_FORMAT_CONFIG .
     fi
     git describe --tags --abbrev=0 --always \
-    | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cc' '*.hpp' \
+    | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
     | xargs -r $CLANG_FORMAT_BIN -i
 }
 


### PR DESCRIPTION
For our clang-format utility - we use git to obtain a list of files to run the formatter against.

To speed up formatting and linting we attempt to get a subset of the projects files. We currently use `git describe --tags`. This is a reasonable heuristic - but it will not work properly if the project does not have tags.

This PR adds a rule that will use `git ls-files` instead for projects that do not have tags at the sacrifice of speed.

# Testing

- Tested in albatross where the issue was discovered: https://github.com/swift-nav/albatross/pull/451