### PR TITLE
feat: add local archive utility

### DIFF
--- a/tools/local_archive.bzl
+++ b/tools/local_archive.bzl
@@ -1,0 +1,19 @@
+def _impl(repository_ctx):
+    repository_ctx.extract(
+        archive = repository_ctx.attr.src,
+        stripPrefix = repository_ctx.attr.strip_prefix
+    )
+    repository_ctx.file(
+        "BUILD.bazel",
+        repository_ctx.attr.build_file_content,
+    )
+
+local_archive = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "src": attr.label(mandatory = True, allow_single_file = True),
+        "build_file_content": attr.string(mandatory = True),
+        "sha256": attr.string(),
+        "strip_prefix": attr.string(),
+    },
+)

--- a/tools/local_archive.bzl
+++ b/tools/local_archive.bzl
@@ -1,7 +1,7 @@
 def _impl(repository_ctx):
     repository_ctx.extract(
         archive = repository_ctx.attr.src,
-        stripPrefix = repository_ctx.attr.strip_prefix
+        stripPrefix = repository_ctx.attr.strip_prefix,
     )
     repository_ctx.file(
         "BUILD.bazel",


### PR DESCRIPTION
Adds a handy `local_archive` utility.

See: https://www.stevenengelhardt.com/2023/03/01/practical-bazel-local_archive-workspace-rule/

Related: https://github.com/swift-nav/swift-toolchains/pull/22