### PR TITLE
Optionally configure the input dir [OI-652]

### DIFF
--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -20,6 +20,10 @@ def _swift_doxygen_impl(ctx):
 
     config = configure_file_impl(ctx, vars, ctx.attr.name + "_Doxyfile")[0].files.to_list()[0]
 
+    input_dir = ""
+    if "PROJECT_SOURCE_DIR" in vars:
+        input_dir = vars["PROJECT_SOURCE_DIR"]
+
     ctx.actions.run_shell(
         inputs = [config] + ctx.files.deps,
         outputs = [doxygen_out],
@@ -36,9 +40,10 @@ def _swift_doxygen_impl(ctx):
         sed -i "s|@DOXYGEN_DOT_FOUND@|$DOXYGEN_DOT_FOUND|g" {config}
         sed -i "s|@DOXYGEN_DOT_PATH@|$DOXYGEN_DOT_PATH|g" {config}
         sed -i "s|@PLANTUML_JAR_PATH@|/usr/local/bin/plantuml.jar|g" {config}
+        sed -i "s|@INPUT_DIR@|{input_dir}|g" {config}
 
         PATH=$PATH doxygen {config}
-        """.format(config = config.path),
+        """.format(config = config.path, input_dir = input_dir),
     )
 
     return [DefaultInfo(files = depset([doxygen_out, config]))]

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -24,6 +24,10 @@ def _swift_doxygen_impl(ctx):
     if "PROJECT_SOURCE_DIR" in vars:
         input_dir = vars["PROJECT_SOURCE_DIR"]
 
+    project_name = ""
+    if "PROJECT_NAME" in vars:
+        project_name = vars["PROJECT_NAME"]
+
     ctx.actions.run_shell(
         inputs = [config] + ctx.files.deps,
         outputs = [doxygen_out],
@@ -41,9 +45,10 @@ def _swift_doxygen_impl(ctx):
         sed -i "s|@DOXYGEN_DOT_PATH@|$DOXYGEN_DOT_PATH|g" {config}
         sed -i "s|@PLANTUML_JAR_PATH@|/usr/local/bin/plantuml.jar|g" {config}
         sed -i "s|@INPUT_DIR@|{input_dir}|g" {config}
+        sed -i "s|@PROJECT_NAME@|{project_name}|g" {config}
 
         PATH=$PATH doxygen {config}
-        """.format(config = config.path, input_dir = input_dir),
+        """.format(config = config.path, input_dir = input_dir, project_name = project_name),
     )
 
     return [DefaultInfo(files = depset([doxygen_out, config]))]


### PR DESCRIPTION
### Jira ticket
https://swift-nav.atlassian.net/browse/OI-652

### Background
The companion PR in orion-engine https://github.com/swift-nav/orion-engine/pull/7170 needs these changes in order to configure INPUT_DIR and PROJECT_NAME in the `Doxygen.in` file in orion-engine repo.
This Bazel rule is also used from Starling, but the `Doxygen.in` file in Starling does not have the `@INPUT_DIR@` or `@PROJECT_NAME@` tags so the replace with `sed` should not have any effect there.

### Testing
- [x] Tested in orion-engine: https://github.com/swift-nav/orion-engine/pull/7170
- [x] Smoke tested in Starling: https://github.com/swift-nav/starling/pull/8658
