### PR TITLE
fix: various mac build fixes and improvements [DIP-311]

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -55,6 +55,18 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+bool_flag(
+    name = "enable_shared",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_enable_shared",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 # Disable warnings as errors with --@rules_swiftnav//cc:warnings_as_errors=false
 bool_flag(
     name = "warnings_as_errors",

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -63,7 +63,7 @@ bool_flag(
 
 config_setting(
     name = "_enable_shared",
-    build_setting_default = False,
+    flag_values = {":enable_shared": "true"},
     visibility = ["//visibility:public"],
 )
 

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -16,7 +16,7 @@ exports_files(
     visibility = ["//visibility:public"],
 )
 
-# Disable tests and test libraries with --@rules_swiftnav//:disable_test=true
+# Disable tests and test libraries with --@rules_swiftnav///cc:disable_test=true
 bool_flag(
     name = "disable_tests",
     build_setting_default = False,
@@ -29,7 +29,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# Enable exceptions with --@rules_swiftnav//:enable_exceptions=true
+# Enable exceptions with --@rules_swiftnav//cc:enable_exceptions=true
 bool_flag(
     name = "enable_exceptions",
     build_setting_default = False,
@@ -42,7 +42,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# Enable rtti with --@rules_swiftnav//:enable_exceptions=true
+# Enable rtti with --@rules_swiftnav//cc:enable_exceptions=true
 bool_flag(
     name = "enable_rtti",
     build_setting_default = False,
@@ -55,6 +55,7 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# Enable shared linking with --@rules_swiftnav//cc:enable_shared=true
 bool_flag(
     name = "enable_shared",
     build_setting_default = False,
@@ -87,21 +88,21 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
-# Enable with --@rules_swiftnav//:cxx_standard=17
+# Enable with --@rules_swiftnav//cc:cxx_standard=17
 config_setting(
     name = "cxx17",
     flag_values = {":cxx_standard": "17"},
     visibility = ["//visibility:public"],
 )
 
-# Enable with --@rules_swiftnav//:cxx_standard=20
+# Enable with --@rules_swiftnav//cc:cxx_standard=20
 config_setting(
     name = "cxx20",
     flag_values = {":cxx_standard": "20"},
     visibility = ["//visibility:public"],
 )
 
-# Enable with --@rules_swiftnav//:cxx_standard=23
+# Enable with --@rules_swiftnav//cc:cxx_standard=23
 config_setting(
     name = "cxx23",
     flag_values = {":cxx_standard": "23"},

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -77,9 +77,9 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
-def _link_static(linkstatic = False):
+def _link_static(linkstatic = True):
     return select({
-        Label("//cc:_enable_shared"): True,
+        Label("//cc:_enable_shared"): False,
         "//conditions:default": linkstatic,
     })
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -220,6 +220,8 @@ def swift_c_library(**kwargs):
 
     kwargs["tags"] = [LIBRARY] + kwargs.get("tags", [])
 
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+
     native.cc_library(**kwargs)
 
 def swift_cc_library(**kwargs):
@@ -271,6 +273,8 @@ def swift_cc_library(**kwargs):
 
     kwargs["tags"] = [LIBRARY] + kwargs.get("tags", [])
 
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+
     native.cc_library(**kwargs)
 
 def swift_c_tool_library(**kwargs):
@@ -312,6 +316,8 @@ def swift_c_tool_library(**kwargs):
     c_standard = _c_standard(extensions, standard)
 
     kwargs["copts"] = copts + c_standard + kwargs.get("copts", [])
+
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
 
     native.cc_library(**kwargs)
 
@@ -358,6 +364,8 @@ def swift_cc_tool_library(**kwargs):
 
     kwargs["copts"] = copts + cxxopts + kwargs.get("copts", [])
 
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+
     native.cc_library(**kwargs)
 
 def swift_c_binary(**kwargs):
@@ -403,6 +411,8 @@ def swift_c_binary(**kwargs):
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
 
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
+
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
 
     native.cc_binary(**kwargs)
 
@@ -567,6 +577,8 @@ def swift_cc_test_library(**kwargs):
     kwargs["tags"] = [TEST_LIBRARY] + kwargs.get("tags", [])
 
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()
+
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
 
     native.cc_library(**kwargs)
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -77,7 +77,7 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
-def _link_static(linkstatic):
+def _link_static(linkstatic = False):
     return select({
         Label("//cc:_enable_shared"): True,
         "//conditions:default": linkstatic,

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -633,6 +633,7 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
+
     # should we just always build test binaries statically?
     kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
     kwargs["name"] = name

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -633,9 +633,7 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
-
-    # should we just always build test binaries statically?
-    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
+    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
     kwargs["name"] = name
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -77,6 +77,12 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
+def _link_static(linkstatic):
+    return select({
+        Label("//cc:_enable_shared"): True,
+        "//conditions:default": linkstatic,
+    })
+
 # Disable building when --//:disable_tests=true or when building on windows
 def _test_compatible_with():
     return select({
@@ -220,7 +226,7 @@ def swift_c_library(**kwargs):
 
     kwargs["tags"] = [LIBRARY] + kwargs.get("tags", [])
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_library(**kwargs)
 
@@ -273,7 +279,7 @@ def swift_cc_library(**kwargs):
 
     kwargs["tags"] = [LIBRARY] + kwargs.get("tags", [])
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_library(**kwargs)
 
@@ -317,7 +323,7 @@ def swift_c_tool_library(**kwargs):
 
     kwargs["copts"] = copts + c_standard + kwargs.get("copts", [])
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_library(**kwargs)
 
@@ -364,7 +370,7 @@ def swift_cc_tool_library(**kwargs):
 
     kwargs["copts"] = copts + cxxopts + kwargs.get("copts", [])
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_library(**kwargs)
 
@@ -412,7 +418,7 @@ def swift_c_binary(**kwargs):
 
     kwargs["tags"] = [BINARY] + kwargs.get("tags", [])
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_binary(**kwargs)
 
@@ -578,7 +584,7 @@ def swift_cc_test_library(**kwargs):
 
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()
 
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
 
     native.cc_library(**kwargs)
 
@@ -627,7 +633,8 @@ def swift_cc_test(name, type, **kwargs):
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
-    kwargs["linkstatic"] = kwargs.get("linkstatic", True)
+    # should we just always build test binaries statically?
+    kwargs["linkstatic"] = _link_static(kwargs.get("linkstatic", True))
     kwargs["name"] = name
     kwargs["tags"] = [TEST, type] + kwargs.get("tags", [])
     kwargs["target_compatible_with"] = kwargs.get("target_compatible_with", []) + _test_compatible_with()

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -108,12 +108,6 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
-            # This will issue a warning on macOS ventura; see:
-            # https://github.com/python/cpython/issues/97524
-            # https://developer.apple.com/forums/thread/719961
-            "-undefined",
-            "dynamic_lookup",
-            "-Wl,-no_fixup_chains",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -1449,8 +1449,8 @@ cc_toolchain_config = rule(
         "supports_start_end_lib": attr.bool(),
         "builtin_sysroot": attr.string(),
         "_xcode_config": attr.label(default = configuration_field(
-                fragment = "apple",
-                name = "xcode_config_label",
+            fragment = "apple",
+            name = "xcode_config_label",
         )),
     },
     fragments = ["apple"],

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -29,6 +29,11 @@ load(
 )
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
+def _target_os_version(ctx):
+    platform_type = ctx.fragments.apple.single_arch_platform.platform_type
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    return xcode_config.minimum_os_for_platform_type(platform_type)
+
 def layering_check_features(compiler):
     if compiler != "clang":
         return []
@@ -1283,6 +1288,17 @@ def _impl(ctx):
         ],
     )
 
+    macos_minimum_os_feature = feature(
+        name = "macos_minimum_os",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions + all_link_actions,
+                flag_groups = [flag_group(flags = ["-mmacos-version-min={}".format(_target_os_version(ctx))])],
+            ),
+        ],
+    )
+
     is_linux = ctx.attr.target_libc != "macosx"
     libtool_feature = feature(
         name = "libtool",
@@ -1365,6 +1381,7 @@ def _impl(ctx):
             asan_feature,
             tsan_feature,
             ubsan_feature,
+            macos_minimum_os_feature,
         ] + (
             [
                 supports_start_end_lib_feature,
@@ -1431,6 +1448,11 @@ cc_toolchain_config = rule(
         "coverage_link_flags": attr.string_list(),
         "supports_start_end_lib": attr.bool(),
         "builtin_sysroot": attr.string(),
+        "_xcode_config": attr.label(default = configuration_field(
+                fragment = "apple",
+                name = "xcode_config_label",
+        )),
     },
+    fragments = ["apple"],
     provides = [CcToolchainConfigInfo],
 )

--- a/third_party/check.BUILD
+++ b/third_party/check.BUILD
@@ -22,6 +22,10 @@ cmake(
         "CMAKE_INSTALL_LIBDIR": "lib",
         "HAVE_SUBUNIT": "0",
     },
+    generate_args = [
+        "-GNinja",
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0",
+    ],
     lib_source = ":srcs",
     linkopts = select({
         "@bazel_tools//src/conditions:darwin": ["-lpthread"],
@@ -30,10 +34,6 @@ cmake(
             "-lrt",
         ],
     }),
-    generate_args = [
-        "-GNinja",
-        "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0",
-    ],
     out_static_libs = select({
         "@bazel_tools//src/conditions:windows": ["check.lib"],
         "//conditions:default": ["libcheck.a"],

--- a/third_party/check.BUILD
+++ b/third_party/check.BUILD
@@ -30,6 +30,10 @@ cmake(
             "-lrt",
         ],
     }),
+    generate_args = [
+        "-GNinja",
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0",
+    ],
     out_static_libs = select({
         "@bazel_tools//src/conditions:windows": ["check.lib"],
         "//conditions:default": ["libcheck.a"],

--- a/third_party/nlopt.BUILD
+++ b/third_party/nlopt.BUILD
@@ -26,6 +26,8 @@ cmake(
         "CMAKE_INSTALL_LIBDIR": "lib",
     },
     generate_args = [
+        "-GNinja",
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=13.0",
         "-DBUILD_SHARED_LIBS=OFF",
         "-DNLOPT_PYTHON=OFF",
         "-DNLOPT_OCTAVE=OFF",


### PR DESCRIPTION
The recent macos sdk v15 update has caused a number of issues with our builds that require various tweaks to our build settings to fix.

## Switch to ninja for cmake generator

The `cmake` build process involves bootstrapping a gnu make binary from source. The update has caused some strange build errors during this process. More info can be found in the ticket I've created here: https://github.com/bazelbuild/rules_foreign_cc/issues/1099

In the meantime we can just switch to using the ninja generator.

## Drop support for shared linking

We make liberal use of "weak linking" for various purposes across the codebase - usually implemented using function pointers for (I assume) portability.

However, this means that most of our libraries can't really be built as shared libraries due to resulting "undefined reference" errors.

In bazel the build system will by default always try to build the shared library unless `linkstatic` is set to `True`. So on mac this was causing errors during the normal build. Not sure why linux was not having problems (all our CMake builds fail when `-DBUILD_SHARED_LIBS=TRUE`).

To fix this I added `-undefined dynamic_lookup` to the link flags on mac to tell the linker we'll supply the symbols later at the final link step.

Now with the update, for whatever reason these flags appear to be causing the following crash on m1 macs when the linker tries to link a binary:
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
0  0x102277648  __assert_rtn + 72
1  0x10224c6c8  ld::AtomFileConsolidator::addAtomFile(ld::AtomFile const*, ld::AtomFile const*, bool) + 4860
2  0x1022581d0  ld::AtomFileConsolidator::addAtomFile(ld::AtomFile const*) + 148
3  0x102275b20  ld::pass::stubs(ld::Options const&, ld::AtomFileConsolidator&) + 1644
4  0x10225f84c  ld::AtomFileConsolidator::resolve() + 12232
5  0x1021ea1a8  main + 9104
ld: Assertion failed: (slot < _sideTableBuffer.size()), function addAtom, file AtomFileConsolidator.cpp, line 2158.
clang: error: linker command failed with exit code 1 (use -v to see invocation)
INFO: Elapsed time: 190.377s, Critical Path: 36.73s
INFO: 1484 processes: 210 internal, 1274 darwin-sandbox.
FAILED: Build did NOT complete successfully
```

Since we've never really supported shared linking except in some exceptional cases, I've disabled shared library builds by default across all our code and thus can remove the problematic flags (and probably get a perf boost as well).

## Make the minimum macos target consistent

Another annoyance with the mac builds was that the bazel code was getting compiled with a different macos deployment target than the cmake libraries, which resulting in the build output getting spammed with linker warnings referencing this difference.

On my system the bazel target was `13.0`, while the cmake value was `13.6`. I'm not sure how (as of our current version of bazel 6.2) this value is computed.

In CMake it's interpolated from the system.

To fix this I've wired up our toolchain to respect the [macos_minimum_os](https://bazel.build/reference/command-line-reference#flag--macos_minimum_os) flags and add `-mmacos-version-min` to our build. This is just taken from the most recent `HEAD` of `bazel` which is not in 6.x.

The CMake side requires explicitly setting [CMAKE_OSX_DEPLOYMENT_TARGET](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html) variable to the same value.

It would be better if `rules_foreign_cc` also respected the `macos_minimum_os` flag so the value would not have to be hardcoded. We can perhaps open a ticket to request this.

`13.0` seems like a reasonable minimum deployment target since these builds are only intended for development machines.

## Testing

I've tested these changes on m1 and intel macs as well as the following test PR's:
- https://github.com/swift-nav/starling/pull/8677
- https://github.com/swift-nav/orion-engine/pull/7239