### PR TITLE
Doxygen: include all formats in the zip [OI-652]

### DIFF
--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -89,11 +89,14 @@ def swift_doxygen(**kwargs):
     tags = ["manual"] + kwargs.get("tags", [])
     name = kwargs["name"]
     name_html = name + "_html"
+    name_doxygen = name + "_doxygen"
     name_zip = name + "_zip"
 
     kwargs["tags"] = tags
 
     _swift_doxygen(**kwargs)
+
+    print("name_doxygen is: " + name_doxygen)
 
     _filter_html(
         name = name_html,
@@ -104,8 +107,8 @@ def swift_doxygen(**kwargs):
 
     pkg_zip(
         name = name_zip,
-        srcs = [name_html],
+        srcs = [name_doxygen],
         tags = tags,
         package_file_name = name + ".zip",
-        strip_prefix = name_html,
+        strip_prefix = name_doxygen,
     )

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -89,14 +89,11 @@ def swift_doxygen(**kwargs):
     tags = ["manual"] + kwargs.get("tags", [])
     name = kwargs["name"]
     name_html = name + "_html"
-    name_doxygen = name + "_doxygen"
     name_zip = name + "_zip"
 
     kwargs["tags"] = tags
 
     _swift_doxygen(**kwargs)
-
-    print("name_doxygen is: " + name_doxygen)
 
     _filter_html(
         name = name_html,
@@ -105,10 +102,11 @@ def swift_doxygen(**kwargs):
         html_path = name + "_doxygen/html",
     )
 
+    # We zip the full Doxygen output (all formats), not only the HTML
     pkg_zip(
         name = name_zip,
-        srcs = [name_doxygen],
+        srcs = [name],
         tags = tags,
         package_file_name = name + ".zip",
-        strip_prefix = name_doxygen,
+        strip_prefix = name,
     )


### PR DESCRIPTION
### Background
From orion-engine we would like to have also the xml format of Doxygen output exported to S3.

### Change
Previously only the subfolder `html` of Doxygen output was put into the .zip. With this change it zips one level higher, which means the subfolders for each output formats are included in the .zip file.
