### PR TITLE
cc: quiet builds

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -29,6 +29,19 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# Enable warnings for deprecated declarations with --@rules_swiftnav//cc:warn_deprecated_declarations=true
+bool_flag(
+    name = "warn_deprecated_declarations",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "_warn_deprecated_declarations",
+    flag_values = {":warn_deprecated_declarations": "true"},
+    visibility = ["//visibility:public"],
+)
+
 # Enable exceptions with --@rules_swiftnav//cc:enable_exceptions=true
 bool_flag(
     name = "enable_exceptions",

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -29,16 +29,16 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
-# Enable warnings for deprecated declarations with --@rules_swiftnav//cc:warn_deprecated_declarations=true
+# Enable warnings in tests for deprecated declarations with --@rules_swiftnav//cc:tests_warn_deprecated_declarations=true
 bool_flag(
-    name = "warn_deprecated_declarations",
+    name = "tests_warn_deprecated_declarations",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 
 config_setting(
-    name = "_warn_deprecated_declarations",
-    flag_values = {":warn_deprecated_declarations": "true"},
+    name = "_tests_warn_deprecated_declarations",
+    flag_values = {":tests_warn_deprecated_declarations": "true"},
     visibility = ["//visibility:public"],
 )
 

--- a/cc/copts.bzl
+++ b/cc/copts.bzl
@@ -1,6 +1,9 @@
-# The following are set by default by Bazel:
-# -Wall, -Wunused-but-set-parameter, -Wno-free-heap-object
 DEFAULT_COPTS = [
+    "-Wall",
+    "-Wthread-safety",
+    "-Wunused-but-set-parameter",
+    "-Wno-free-nonheap-object",
+    "-Wself-assign",
     "-Wcast-align",
     "-Wcast-qual",
     "-Wchar-subscripts",

--- a/cc/copts.bzl
+++ b/cc/copts.bzl
@@ -3,8 +3,8 @@ DEFAULT_COPTS = [
     #    clang only - reenable when we move to features.
     #    "-Wthread-safety",
     #    "-Wunused-but-set-parameter",
+    #    "-Wself-assign",
     "-Wno-free-nonheap-object",
-    "-Wself-assign",
     "-Wcast-align",
     "-Wcast-qual",
     "-Wchar-subscripts",

--- a/cc/copts.bzl
+++ b/cc/copts.bzl
@@ -1,7 +1,8 @@
 DEFAULT_COPTS = [
     "-Wall",
-    "-Wthread-safety",
-    "-Wunused-but-set-parameter",
+    #    clang only - reenable when we move to features.
+    #    "-Wthread-safety",
+    #    "-Wunused-but-set-parameter",
     "-Wno-free-nonheap-object",
     "-Wself-assign",
     "-Wcast-align",

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -630,7 +630,7 @@ def swift_cc_test(name, type, **kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = local_includes + kwargs.get("copts", [])
+    kwargs["copts"] = local_includes + kwargs.get("copts", []) + ["-Wno-deprecated-declarations"]
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -122,10 +122,10 @@ def _symbolizer_data():
         "//conditions:default": [],
     })
 
-# Handle whether to enable -Wdeprecated-declarations
-def _warn_deprecated_declarations():
+# Handle whether to enable -Wdeprecated-declarations in tests.
+def _tests_warn_deprecated_declarations():
     return select({
-        Label("//cc:_warn_deprecated_declarations"): [],
+        Label("//cc:_tests_warn_deprecated_declarations"): [],
         "//conditions:default": ["-Wno-deprecated-declarations"],
     })
 
@@ -638,7 +638,7 @@ def swift_cc_test(name, type, **kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = local_includes + kwargs.get("copts", []) + _warn_deprecated_declarations()
+    kwargs["copts"] = local_includes + kwargs.get("copts", []) + _tests_warn_deprecated_declarations()
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -126,7 +126,7 @@ def _symbolizer_data():
 def _warn_deprecated_declarations():
     return select({
         Label("//cc:_warn_deprecated_declarations"): [],
-        "//conditions:default": ["-Wdeprecated-declarations"],
+        "//conditions:default": ["-Wno-deprecated-declarations"],
     })
 
 def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility = None):

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -77,7 +77,6 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
-# Handle whether to enable -Wdeprecated-declarations
 # Handle whether to link statically
 def _link_static(linkstatic = True):
     return select({
@@ -123,6 +122,7 @@ def _symbolizer_data():
         "//conditions:default": [],
     })
 
+# Handle whether to enable -Wdeprecated-declarations
 def _warn_deprecated_declarations():
     return select({
         Label("//cc:_warn_deprecated_declarations"): [],

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -126,7 +126,7 @@ def _symbolizer_data():
 def _warn_deprecated_declarations():
     return select({
         Label("//cc:_warn_deprecated_declarations"): [],
-        "//conditions:default": ["-Wno-deprecated-declarations"],
+        "//conditions:default": ["-Wdeprecated-declarations"],
     })
 
 def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility = None):

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -77,6 +77,8 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
 def _construct_local_includes(local_includes):
     return [construct_local_include(path) for path in local_includes]
 
+# Handle whether to enable -Wdeprecated-declarations
+# Handle whether to link statically
 def _link_static(linkstatic = True):
     return select({
         Label("//cc:_enable_shared"): False,
@@ -119,6 +121,12 @@ def _symbolizer_data():
         Label("//cc:enable_symbolizer_x86_64_linux"): ["@x86_64-linux-llvm//:symbolizer"],
         Label("//cc:enable_symbolizer_x86_64_darwin"): ["@x86_64-darwin-llvm//:symbolizer"],
         "//conditions:default": [],
+    })
+
+def _warn_deprecated_declarations():
+    return select({
+        Label("//cc:_warn_deprecated_declarations"): [],
+        "//conditions:default": ["-Wno-deprecated-declarations"],
     })
 
 def cc_stamped_library(name, out, template, hdrs, includes, defaults, visibility = None):
@@ -630,7 +638,7 @@ def swift_cc_test(name, type, **kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = local_includes + kwargs.get("copts", []) + ["-Wno-deprecated-declarations"]
+    kwargs["copts"] = local_includes + kwargs.get("copts", []) + _warn_deprecated_declarations()
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -53,9 +53,6 @@ def cc_toolchain_config(
         "-ffp-contract=off",
         # Diagnostics
         "-fcolor-diagnostics",
-        "-Wall",
-        "-Wthread-safety",
-        "-Wself-assign",
     ] + extra_copts
 
     # -fstandalone-debug disables options that optimize

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -105,6 +105,7 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
+            "-no_warn_duplicate_labels",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -105,7 +105,7 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
-            "-Wl,no_warn_duplicate_labels",
+            "-Wl,-no_warn_duplicate_labels",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -106,7 +106,7 @@ def cc_toolchain_config(
         link_flags.extend([
             "-headerpad_max_install_names",
             "-Wl,-no_warn_duplicate_libraries",
-            "-Wl,-no_warn_rename_duplicate_member_name",
+            "-Wl,-no_warn_duplicate_member_name",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -106,7 +106,7 @@ def cc_toolchain_config(
         link_flags.extend([
             "-headerpad_max_install_names",
             "-Wl,-no_warn_duplicate_libraries",
-            "-Wl,-no_warn_duplicate_member_name",
+            "-Wl,-no_warn_duplicate_member",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -105,7 +105,7 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
-            "-Wl,-no_warn_duplicate_labels",
+            "-Wl,-no_warn_duplicate_libraries",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -106,7 +106,7 @@ def cc_toolchain_config(
         link_flags.extend([
             "-headerpad_max_install_names",
             "-Wl,-no_warn_duplicate_libraries",
-            "-Wl,-no_warn_rename_duplicate_member",
+            "-Wl,-no_warn_rename_duplicate_member_name",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -188,8 +188,6 @@ def cc_toolchain_config(
 
     supports_start_end_lib = use_lld
 
-    # Calls https://github.com/bazelbuild/bazel/blob/master/tools/cpp/unix_cc_toolchain_config.bzl
-    # Which defines the rule that actually sets up the cc toolchain.
     unix_cc_toolchain_config(
         name = name,
         cpu = target_cpu,

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -106,6 +106,7 @@ def cc_toolchain_config(
         link_flags.extend([
             "-headerpad_max_install_names",
             "-Wl,-no_warn_duplicate_libraries",
+            "-Wl,-no_warn_rename_duplicate_member",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -105,7 +105,7 @@ def cc_toolchain_config(
         use_lld = False
         link_flags.extend([
             "-headerpad_max_install_names",
-            "-no_warn_duplicate_labels",
+            "-Wl,no_warn_duplicate_labels",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -106,7 +106,6 @@ def cc_toolchain_config(
         link_flags.extend([
             "-headerpad_max_install_names",
             "-Wl,-no_warn_duplicate_libraries",
-            "-Wl,-no_warn_duplicate_member",
         ])
     else:
         use_lld = True

--- a/cc/toolchains/llvm/swift_custom_features.bzl
+++ b/cc/toolchains/llvm/swift_custom_features.bzl
@@ -1,0 +1,91 @@
+"""Swiftnav custom toolchain features
+
+Our unix_cc_toolchain_config.bzl is a fork of upstream at:
+https://github.com/bazelbuild/bazel/blob/master/tools/cpp/unix_cc_toolchain_config.bzl
+
+For the time being we would like to keep this a super set of the features defined there
+or pull in fixes and new features without upgrading bazel.
+
+In order to keep this maintainable all of our custom additions will be added
+to this file under the swift_ prefix.
+
+Bug fixes, ports of features from newer versions, etc.. should be put as they
+appear in upstream in unix_cc_toolchain_config.bzl.
+"""
+
+_all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+_all_cpp_compile_actions = [
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+]
+
+_preprocessor_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.clif_match,
+]
+
+_codegen_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.lto_backend,
+]
+
+_all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+_lto_index_actions = [
+    ACTION_NAMES.lto_index_for_executable,
+    ACTION_NAMES.lto_index_for_dynamic_library,
+    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+]
+
+# Clang has a set of warnings that are always enabled by default
+# which gets noisey for third party code. This feature allows disabling
+# these warnings for code we likely never intend to patch to focus on
+# warnings we care about.
+swift_no_default_warnings = feature(
+    name = "no_default_warnings",
+    flag_sets = [
+        flag_set(
+            actions = _all_compile_actions,
+            flag_groups = [flag_group(flags = [
+                "-Wno-fortify-source",
+                "-Wno-absolute-value",
+                "-Wno-format",
+                "-Wno-incompatible-pointer-types-discards-qualifiers",
+                "-Wno-implicit-const-in-float-conversion",
+                "-Wno-implicit-function-declaration",
+                "-Wno-mismatched-new-delete",
+            ],)]
+        )
+    ],
+)
+

--- a/cc/toolchains/llvm/swift_custom_features.bzl
+++ b/cc/toolchains/llvm/swift_custom_features.bzl
@@ -90,7 +90,7 @@ swift_no_default_warnings = feature(
                 "-Wno-absolute-value",
                 "-Wno-format",
                 "-Wno-incompatible-pointer-types-discards-qualifiers",
-                "-Wno-implicit-const-in-float-conversion",
+                "-Wno-implicit-const-int-float-conversion",
                 "-Wno-implicit-function-declaration",
                 "-Wno-mismatched-new-delete",
             ],)]

--- a/cc/toolchains/llvm/swift_custom_features.bzl
+++ b/cc/toolchains/llvm/swift_custom_features.bzl
@@ -13,6 +13,15 @@ Bug fixes, ports of features from newer versions, etc.. should be put as they
 appear in upstream in unix_cc_toolchain_config.bzl.
 """
 
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "feature",
+    "flag_group",
+    "flag_set",
+)
+
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
 _all_compile_actions = [
     ACTION_NAMES.c_compile,
     ACTION_NAMES.cpp_compile,

--- a/cc/toolchains/llvm/swift_custom_features.bzl
+++ b/cc/toolchains/llvm/swift_custom_features.bzl
@@ -19,7 +19,6 @@ load(
     "flag_group",
     "flag_set",
 )
-
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 
 _all_compile_actions = [
@@ -93,8 +92,7 @@ swift_no_default_warnings = feature(
                 "-Wno-implicit-const-int-float-conversion",
                 "-Wno-implicit-function-declaration",
                 "-Wno-mismatched-new-delete",
-            ],)]
-        )
+            ])],
+        ),
     ],
 )
-

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -989,7 +989,7 @@ def _impl(ctx):
             flag_set(
                 actions = [ACTION_NAMES.cpp_link_static_library],
                 flag_groups = [
-                    flag_group(flags = ["-no_warning_for_no_symbols", "-static", "-s"]),
+                    flag_group(flags = ["-no_warning_for_no_symbols", "-no_warning_for_duplicate_member_name", "-static", "-s"]),
                     flag_group(
                         flags = ["-o", "%{output_execpath}"],
                         expand_if_available = "output_execpath",

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -28,6 +28,7 @@ load(
     "with_feature_set",
 )
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+load("swift_custom_features.bzl", "swift_no_default_warnings")
 
 def _target_os_version(ctx):
     platform_type = ctx.fragments.apple.single_arch_platform.platform_type
@@ -1252,26 +1253,6 @@ def _impl(ctx):
         ],
     )
 
-    no_default_warnings = feature(
-        name = "no_default_warnings",
-        flag_sets = [
-            flag_set(
-                actions = all_compile_actions,
-                flag_groups = [flag_group(flags = [
-                    "-Wno-fortify-source",
-                    "-Wno-absolute-value",
-                    "-Wno-format",
-                    "-Wno-incompatible-pointer-types-discards-qualifiers",
-                    "-Wno-implicit-const-in-float-conversion",
-                    "-Wno-implicit-function-declaration",
-                    "-Wno-mismatched-new-delete",
-                ],)]
-            )
-        ],
-    )
-            
-
-
     archive_param_file_feature = feature(
         name = "archive_param_file",
         enabled = True,
@@ -1383,7 +1364,10 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
-        ] + layering_check_features(ctx.attr.compiler)
+        ] + layering_check_features(ctx.attr.compiler) + [
+            # append swiftnavs custom features here.
+            swift_no_default_warnings,
+        ]
     else:
         # macOS artifact name patterns differ from the defaults only for dynamic
         # libraries.
@@ -1422,7 +1406,10 @@ def _impl(ctx):
             unfiltered_compile_flags_feature,
             treat_warnings_as_errors_feature,
             archive_param_file_feature,
-        ] + layering_check_features(ctx.attr.compiler)
+        ] + layering_check_features(ctx.attr.compiler) + [
+            # append swiftnavs custom features here
+            swift_no_default_warnings,
+        ]
 
     return cc_common.create_cc_toolchain_config_info(
         ctx = ctx,

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -989,7 +989,7 @@ def _impl(ctx):
             flag_set(
                 actions = [ACTION_NAMES.cpp_link_static_library],
                 flag_groups = [
-                    flag_group(flags = ["-no_warning_for_no_symbols", "-no_warning_for_duplicate_member_name", "-static", "-s"]),
+                    flag_group(flags = ["-no_warning_for_no_symbols", "-static", "-s"]),
                     flag_group(
                         flags = ["-o", "%{output_execpath}"],
                         expand_if_available = "output_execpath",

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -1252,6 +1252,26 @@ def _impl(ctx):
         ],
     )
 
+    no_default_warnings = feature(
+        name = "no_default_warnings",
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [flag_group(flags = [
+                    "-Wno-fortify-source",
+                    "-Wno-absolute-value",
+                    "-Wno-format",
+                    "-Wno-incompatible-pointer-types-discards-qualifiers",
+                    "-Wno-implicit-const-in-float-conversion",
+                    "-Wno-implicit-function-declaration",
+                    "-Wno-mismatched-new-delete",
+                ],)]
+            )
+        ],
+    )
+            
+
+
     archive_param_file_feature = feature(
         name = "archive_param_file",
         enabled = True,

--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -989,7 +989,7 @@ def _impl(ctx):
             flag_set(
                 actions = [ACTION_NAMES.cpp_link_static_library],
                 flag_groups = [
-                    flag_group(flags = ["-static", "-s"]),
+                    flag_group(flags = ["-no_warning_for_no_symbols", "-static", "-s"]),
                     flag_group(
                         flags = ["-o", "%{output_execpath}"],
                         expand_if_available = "output_execpath",

--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -37,9 +37,9 @@ cc_library(
             "/Zc:preprocessor-",
         ],
         "//conditions:default": [
-            "-Wno-error=implicit-function-declaration",
             "-Wno-format",
             "-Wno-incompatible-pointer-types-discards-qualifiers",
+            "-Wno-implicit-function-declerations",
         ],
     }),
     includes = [

--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -39,7 +39,7 @@ cc_library(
         "//conditions:default": [
             "-Wno-format",
             "-Wno-incompatible-pointer-types-discards-qualifiers",
-            "-Wno-implicit-function-declarations",
+            "-Wno-implicit-function-declaration",
         ],
     }),
     includes = [

--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -38,6 +38,8 @@ cc_library(
         ],
         "//conditions:default": [
             "-Wno-error=implicit-function-declaration",
+            "-Wno-format",
+            "-Wno-incompatible-pointer-types-discards-qualifiers",
         ],
     }),
     includes = [

--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -39,7 +39,7 @@ cc_library(
         "//conditions:default": [
             "-Wno-format",
             "-Wno-incompatible-pointer-types-discards-qualifiers",
-            "-Wno-implicit-function-declerations",
+            "-Wno-implicit-function-declarations",
         ],
     }),
     includes = [

--- a/third_party/hdf5.BUILD
+++ b/third_party/hdf5.BUILD
@@ -36,12 +36,9 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [
             "/Zc:preprocessor-",
         ],
-        "//conditions:default": [
-            "-Wno-format",
-            "-Wno-incompatible-pointer-types-discards-qualifiers",
-            "-Wno-implicit-function-declaration",
-        ],
+        "//conditions:default": [],
     }),
+    features = ["no_default_warnings"],
     includes = [
         "config",
         "src",
@@ -61,10 +58,9 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [
             "/Zc:preprocessor-",
         ],
-        "//conditions:default": [
-            "-Wno-error=implicit-function-declaration",
-        ],
+        "//conditions:default": [],
     }),
+    features = ["no_default_warnings"],
     includes = [
         "hl/src",
     ],

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -286,6 +286,7 @@ cc_library(
         "libdispatch",
         "libsrc",
     ],
+    copts = ["-Wno-implicit-const-int-float-conversion"],
     textual_hdrs = dispatch_textual_hdrs,
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -278,6 +278,7 @@ cc_library(
         "liblib/nc_initialize.c",
     ],
     hdrs = hdrs,
+    copts = ["-Wno-implicit-const-int-float-conversion"],
     defines = ["HAVE_CONFIG_H"],
     # Allows including <config.h> with angle brackets
     include_prefix = ".",
@@ -286,7 +287,6 @@ cc_library(
         "libdispatch",
         "libsrc",
     ],
-    copts = ["-Wno-implicit-const-int-float-conversion"],
     textual_hdrs = dispatch_textual_hdrs,
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/netcdf-c.BUILD
+++ b/third_party/netcdf-c.BUILD
@@ -278,8 +278,8 @@ cc_library(
         "liblib/nc_initialize.c",
     ],
     hdrs = hdrs,
-    copts = ["-Wno-implicit-const-int-float-conversion"],
     defines = ["HAVE_CONFIG_H"],
+    features = ["no_default_warnings"],
     # Allows including <config.h> with angle brackets
     include_prefix = ".",
     includes = [

--- a/third_party/netcdf-cxx.BUILD
+++ b/third_party/netcdf-cxx.BUILD
@@ -76,7 +76,7 @@ cc_library(
         "cxx4/netcdf",
         "cxx4/test_utilities.h",
     ],
-    copts = ["-Wno-mismatched-new-delete"],
+    features = ["no_default_warnings"],
     includes = ["cxx4"],
     visibility = ["//visibility:public"],
     deps = [

--- a/third_party/netcdf-cxx.BUILD
+++ b/third_party/netcdf-cxx.BUILD
@@ -76,8 +76,8 @@ cc_library(
         "cxx4/netcdf",
         "cxx4/test_utilities.h",
     ],
-    includes = ["cxx4"],
     copts = ["-Wno-mismatched-new-delete"],
+    includes = ["cxx4"],
     visibility = ["//visibility:public"],
     deps = [
         "@netcdf-c",

--- a/third_party/netcdf-cxx.BUILD
+++ b/third_party/netcdf-cxx.BUILD
@@ -77,6 +77,7 @@ cc_library(
         "cxx4/test_utilities.h",
     ],
     includes = ["cxx4"],
+    copts = ["-Wno-mismatched-new-delete"],
     visibility = ["//visibility:public"],
     deps = [
         "@netcdf-c",

--- a/third_party/suitesparse.BUILD
+++ b/third_party/suitesparse.BUILD
@@ -305,6 +305,9 @@ cc_library(
     includes = [
         "CHOLMOD/SuiteSparse_metis/GKlib",
     ],
+    copts = [
+        "-Wno-fortify-source"
+    ],
     linkopts = [
         "-lm",
         "-lpthread",
@@ -381,6 +384,7 @@ cc_library(
     ],
     copts = [
         "-Iexternal/suitesparse/CHOLMOD/SuiteSparse_metis/libmetis/",
+        "-Wno-absolute-value",
     ],
     includes = [
         "CHOLMOD/SuiteSparse_metis/include/",

--- a/third_party/suitesparse.BUILD
+++ b/third_party/suitesparse.BUILD
@@ -299,12 +299,10 @@ cc_library(
     hdrs = [
         "CHOLMOD/SuiteSparse_metis/GKlib/GKlib.h",
     ],
-    copts = [
-        "-Wno-fortify-source",
-    ],
     defines = [
         "LINUX",
     ],
+    features = ["no_default_warnings"],
     includes = [
         "CHOLMOD/SuiteSparse_metis/GKlib",
     ],
@@ -384,8 +382,8 @@ cc_library(
     ],
     copts = [
         "-Iexternal/suitesparse/CHOLMOD/SuiteSparse_metis/libmetis/",
-        "-Wno-absolute-value",
     ],
+    features = ["no_default_warnings"],
     includes = [
         "CHOLMOD/SuiteSparse_metis/include/",
     ],

--- a/third_party/suitesparse.BUILD
+++ b/third_party/suitesparse.BUILD
@@ -299,14 +299,14 @@ cc_library(
     hdrs = [
         "CHOLMOD/SuiteSparse_metis/GKlib/GKlib.h",
     ],
+    copts = [
+        "-Wno-fortify-source",
+    ],
     defines = [
         "LINUX",
     ],
     includes = [
         "CHOLMOD/SuiteSparse_metis/GKlib",
-    ],
-    copts = [
-        "-Wno-fortify-source"
     ],
     linkopts = [
         "-lm",


### PR DESCRIPTION
Removes noise in our builds so we can focus on warnings and issues that matter.

# Design Notes

## Remove default warnings from toolchain

The OTB bazel cc toolchain adds a few warnings to the compile line for every file (i.e. `-Wall`). 
We've kept this convention but it has made our builds extremely noisy, particularly when building 
third party code.

I've moved these options to only be added in our `swift_cc` wrappers.

## Silence implicit warnings when building third party code

Clang has a handful of warnings that are always on by default. I've added a new feature to our 
toolchain that disables these warnings when building third party code so that builds aren't 
spammed by warnings we're not likely to ever fix.

This has the downside of masking poor code hygiene in our dependencies, but
the option can be overridden at the command line:
`bazel build --features=-no_default_warnings //...`

## Silence warnings about no symbols on macos

Libtool outputs a warning message if a file has no symbols. This shows up quite
frequently in our builds - for instance in cases like `boringssl` where entire files
are `#ifdef'd` away due to platform.

This is something we can ignore.

## Silence warnings about duplicate libraries on macos

This one is new with the latest linker upgrade. Now `ld` will issue a warning if
for instance `-lpthread -lpthread` ends up on the link line.

This duplication is unavoidable in a big c++ codebase as you can't assume someone
else is going to provide the dependency for you.

## Silence -Wno-deprecated-declarations in tests

This mostly comes from the extensive use of deprecated api's in gtest.
I've added a flag so that this can be re-enabled locally.

# Testing

I've tested the changes on both darwin platforms and linux and the difference is
night and day.

The two following test PR's should satisfy that no major regressions have been introduced:
- https://github.com/swift-nav/starling/pull/8678
- https://github.com/swift-nav/orion-engine/pull/7243