### PR TITLE
cc: toolchain: add support for native aarch64-linux builds [DIP-223]

### DIFF
--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -99,6 +99,7 @@ filegroup(
 def register_swift_cc_toolchains():
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin")
+    native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/aarch64-linux:cc-toolchain-aarch64-linux")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton2")
     native.register_toolchains("@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton3")

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -16,6 +16,8 @@ AARCH64_DARWIN_LLVM = "https://github.com/swift-nav/swift-toolchains/releases/do
 
 X86_64_DARWIN_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang%2Bllvm-14.0.0-x86_64-apple-darwin.tar.xz"
 
+AARCH64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang%2Bllvm-14.0.0-aarch64-linux-gnu.tar.xz"
+
 X86_64_LINUX_LLVM = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
 
 AARCH64_LINUX_MUSL = "https://github.com/swift-nav/swift-toolchains/releases/download/musl-cross-11.2.0/aarch64-linux-musl-cross.tar.gz"
@@ -45,6 +47,14 @@ def swift_cc_toolchain():
         url = X86_64_DARWIN_LLVM,
         strip_prefix = "clang+llvm-14.0.0-x86_64-apple-darwin",
         sha256 = "cf5af0f32d78dcf4413ef6966abbfd5b1445fe80bba57f2ff8a08f77e672b9b3",
+    )
+
+    maybe(
+        http_archive,
+        name = "aarch64-linux-llvm",
+        build_file = Label("//cc/toolchains/llvm:llvm.BUILD.bzl"),
+        url = AARCH64_LINUX_LLVM,
+        strip_prefix = "clang+llvm-14.0.0-aarch64-linux-gnu",
     )
 
     maybe(

--- a/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
@@ -1,0 +1,179 @@
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//cc/toolchains/llvm:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("//cc/toolchains/llvm:target_triplets.bzl", "AARCH64_LINUX")
+
+filegroup(
+    name = "wrappers",
+    srcs = glob([
+        "wrappers/**",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "ar_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:ar",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "as_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:as",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "compiler_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:clang",
+        "@aarch64-linux-llvm//:include",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "dwp_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:dwp",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "linker_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:ar",
+        "@aarch64-linux-llvm//:clang",
+        "@aarch64-linux-llvm//:ld",
+        "@aarch64-linux-llvm//:lib",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "objcopy_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:objcopy",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+filegroup(
+    name = "strip_files",
+    srcs = [
+        ":wrappers",
+        "@aarch64-linux-llvm//:strip",
+    ],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = [
+        "linker_files",
+        ":compiler_files",
+        "@aarch64-linux-llvm//:bin",
+    ] + select({
+        "//cc:_enable_sysroot": ["@aarch64-sysroot"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_toolchain_config(
+    name = "local-aarch64-linux",
+    abi_libc_version = "glibc_unknown",
+    abi_version = "clang",
+    builtin_sysroot = select({
+        "//cc:_enable_sysroot": "external/aarch64-sysroot",
+        "//conditions:default": None,
+    }),
+    compiler = "clang",
+    cxx_builtin_include_directories = select({
+        "//cc:_enable_sysroot": ["%sysroot%/usr/include"],
+        "//conditions:default": [
+            "/include",
+            "/usr/include",
+            "/usr/local/include",
+        ],
+    }),
+    host_system_name = AARCH64_LINUX,
+    target_cpu = "k8",
+    target_libc = "glibc_unknown",
+    target_system_name = AARCH64_LINUX,
+    tool_paths = {
+        "ar": "wrappers/llvm-ar",
+        "cpp": "wrappers/clang-cpp",
+        "gcc": "wrappers/clang",
+        "gcov": "wrappers/llvm-profdata",
+        "llvm-cov": "wrappers/llvm-cov",
+        "llvm-profdata": "wrappers/llvm-profdata",
+        "ld": "wrappers/ld.ldd",
+        "nm": "wrappers/llvm-nm",
+        "objcopy": "wrappers/llvm-objcopy",
+        "objdump": "wrappers/llvm-objdump",
+        "strip": "wrappers/llvm-strip",
+    },
+    toolchain_identifier = "clang-aarch64-linux",
+    toolchain_path_prefix = "external/aarch64-linux-llvm",
+)
+
+cc_toolchain(
+    name = "cc-clang-aarch64-linux",
+    all_files = ":all_files",
+    ar_files = ":ar_files",
+    as_files = ":as_files",
+    compiler_files = ":compiler_files",
+    dwp_files = ":dwp_files",
+    linker_files = ":linker_files",
+    objcopy_files = ":objcopy_files",
+    strip_files = ":strip_files",
+    toolchain_config = ":local-aarch64-linux",
+)
+
+toolchain(
+    name = "cc-toolchain-aarch64-linux",
+    exec_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    target_compatible_with = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+        "//cc/constraints:llvm_toolchain",
+    ],
+    target_settings = None,
+    toolchain = ":cc-clang-aarch64-linux",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/clang
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/clang
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/clang-cpp
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/clang-cpp
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/ld.lld
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/ld.lld
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-ar
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-ar
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-cov
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-cov
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-nm
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-nm
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-objcopy
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-objcopy
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-objdump
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-objdump
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-profdata
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-profdata
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-strip
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/llvm-strip
@@ -1,0 +1,1 @@
+wrapper

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+# Locates the actual tool paths relative to the location this script is 
+# executed from.
+#
+# This is necessary because we download the toolchain using
+# http_archive, which bazel places in _execroot_/external/_repo_name_.
+#
+# Unfortunately we cannot provide this location as the argument of tool_path
+# when configuring the toolchain, because tool_path only takes a relative path.
+#
+# This is the fairly common workaround to handle this.
+#
+# TODO: [BUILD-549] - Remove need for wrapper files
+#
+# Recent versions of Bazel may have introduced a mechanism that removes
+# the need for this workaround: https://github.com/bazelbuild/bazel/issues/7746
+
+set -e
+
+# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+  set -x
+fi
+
+tool_name=$(basename "${BASH_SOURCE[0]}")
+toolchain_bindir=external/aarch64-linux-llvm/bin
+
+if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  # This branch exists because some users of the toolchain,
+  # namely rules_foreign_cc, will change CWD and call $CC (this script)
+  # with its absolute path.
+  #
+  # To deal with this we find the tool relative to this script, which is at
+  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/aarch64-linux/wrappers/wrapper.
+  #
+  # If the wrapper is relocated then this line needs to be adjusted.
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
+  exec "${tool}" "${@}"
+else
+  >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
+  exit 5
+fi
+


### PR DESCRIPTION
Adds support for building with our heremtic clang toolchain on aarch64-linux hosts.

This is all pretty much boilerplate for adding a new llvm toolchain.

Tested here: https://github.com/swift-nav/orion-engine/pull/7290