### PR TITLE
platforms: fix mkl visibility [IO-5]

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -107,6 +107,7 @@ platform(
         "//third_party:intel_mkl",
         "@platforms//cpu:x86_64",
     ],
+    visibility = ["//visibility:public"],
 )
 
 platform(


### PR DESCRIPTION
Forgot to add public visibility to the `mkl` platform which was causing some build failures upstream.