### PR TITLE
[CLDAPPS-896] C++ Asio and Asio-Grpc header only libraries

### DIFF
--- a/third_party/asio-grpc.BUILD
+++ b/third_party/asio-grpc.BUILD
@@ -1,0 +1,20 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "asio-grpc",
+    hdrs = glob(["src/agrpc/**"]),
+    defines = ["AGRPC_STANDALONE_ASIO"],
+    includes = ["src"],
+)

--- a/third_party/asio.BUILD
+++ b/third_party/asio.BUILD
@@ -1,0 +1,22 @@
+# Copyright (C) 2023 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "asio",
+    hdrs = glob([
+        "asio/include/asio.hpp",
+        "asio/include/asio/**",
+    ]),
+    includes = ["asio/include"],
+)


### PR DESCRIPTION
# Changes

Introduces the [Asio C++ library](https://think-async.com/Asio/) and the [Asio gRPC](https://github.com/Tradias/asio-grpc) library to our bazel third party libraries, both are header only libraries, which makes things really easy to setup.

# Related PR

Similar implementation with cmake https://github.com/swift-nav/cmake/pull/170