### PR TITLE
Extra string tags to image_stamp_tag, update codeowners[OC-1439]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @isaactorz
+* @pcrumley
+* @john-michaelburke

--- a/image/defs.bzl
+++ b/image/defs.bzl
@@ -26,34 +26,39 @@ def swift_image_index(name, image, platforms, **kwargs):
         **kwargs
     )
 
-def image_tag(name, tag):
+def image_tag(name, tag, extra_tags = []):
     """
     Creates a tag file from given string
 
     Args:
         name: Name of the tag target
         tag: String that will be used as a tag
+        extra_tags: List of additional string tags. Default is empty.
     """
     native.genrule(
         name = name,
         outs = ["{}.txt".format(name)],
-        cmd = "echo {} > $@".format(tag),
+        cmd = "echo {} && echo {} > $@".format(tag, "\n".join(extra_tags)),
         tags = ["manual"],
     )
 
-def image_stamp_tag(name, var):
+def image_stamp_tag(name, var, extra_tags = []):
     """
     Creates a tag file from a given variable defined in stable-status.txt file
 
     Args:
         name: Name of the tag target
         var: Variable to use as a tag
+        extra_tags: List of additional string tags. Default is empty.
     """
     native.genrule(
         name = name,
         outs = ["{}.txt".format(name)],
         # `(?<=A)B` in regex is a positive lookbehind - finds expression B that's preceded with A
-        cmd = "cat bazel-out/stable-status.txt | grep -Po '(?<={}\\s).*' > $@".format(var),
+        cmd = "cat bazel-out/stable-status.txt | grep -Po '(?<={}\\s).*' && echo {} > $@".format(
+            var,
+            "\n".join(extra_tags),
+        ),
         stamp = True,
         tags = ["manual"],
     )


### PR DESCRIPTION
* Optionally add a list of extra string tags to either the image_tag or image_stamp_tag output.
* At least for my use case, I would like to use image_stamp_tag to tag not only the git version but add in a "latest-master" tag to the target image.
* I could see value in extending the image_stamp_tag to apply the regex functionality to extra tags, but I'll leave that up to a future user.
* As far as I understand, because I use a default value, this feature should be backwards compatible.