### PR TITLE
Replace -g flag by -gdwarf-4 for musl armhf toolchain [AP-3099]

### DIFF
--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -99,7 +99,7 @@ def _impl(ctx):
                     actions = all_compile_actions,
                     flag_groups = ([
                         flag_group(
-                            flags = ["-O2", "-g"],
+                            flags = ["-O2", "-gdwarf-4"],
                         ),
                     ]),
                     with_features = [with_feature_set(features = ["opt"])],


### PR DESCRIPTION
The binutils version of the toolchain seems to be too old for the compiler, expecting DWARF5. This change enforces DWARF4.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100725