### PR TITLE
Add guidelines CCB as owner for guideline relevant files [AP-3170]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @swift-nav/build
+
+# Software Coding Guidelines related
+clang_format/* @swift-nav/coding-guidelines-ccb
+clang_tidy/* @swift-nav/coding-guidelines-ccb


### PR DESCRIPTION
Someone needs to grant @swift-nav/coding-guidelines-ccb write access to this repo