### PR TITLE
clang-format: Use config directly instead of modifying repository [AP-3053]

### DIFF
--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -8,25 +8,17 @@ format_all() {
     CLANG_FORMAT_CONFIG=$(realpath $1)
 
     cd $BUILD_WORKSPACE_DIRECTORY
-    if ! test -f .clang-format; then
-        echo ".clang-format file not found. Bazel will copy the default .clang-format file."
-        cp $CLANG_FORMAT_CONFIG .
-    fi
     git ls-files '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
-    | xargs -r $CLANG_FORMAT_BIN -i
+    | xargs -r $CLANG_FORMAT_BIN -i --style=file:$CLANG_FORMAT_CONFIG
 }
 
 format_diff() {
     CLANG_FORMAT_CONFIG=$(realpath $1)
 
     cd $BUILD_WORKSPACE_DIRECTORY
-    if ! test -f .clang-format; then
-        echo ".clang-format file not found. Bazel will copy the default .clang-format file."
-        cp $CLANG_FORMAT_CONFIG .
-    fi
     git describe --tags --abbrev=0 --always \
     | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
-    | xargs -r $CLANG_FORMAT_BIN -i
+    | xargs -r $CLANG_FORMAT_BIN -i --style=file:$CLANG_FORMAT_CONFIG
 }
 
 check_file() {

--- a/clang_format/run_clang_format.sh
+++ b/clang_format/run_clang_format.sh
@@ -5,20 +5,20 @@
 set -ue
 
 format_all() {
-    CLANG_FORMAT_CONFIG=$(realpath $1)
+    CLANG_FORMAT_CONFIG=$(realpath "$1")
 
-    cd $BUILD_WORKSPACE_DIRECTORY
+    cd "$BUILD_WORKSPACE_DIRECTORY"
     git ls-files '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
-    | xargs -r $CLANG_FORMAT_BIN -i --style=file:$CLANG_FORMAT_CONFIG
+    | xargs -r "$CLANG_FORMAT_BIN" -i --style=file:"$CLANG_FORMAT_CONFIG"
 }
 
 format_diff() {
-    CLANG_FORMAT_CONFIG=$(realpath $1)
+    CLANG_FORMAT_CONFIG=$(realpath "$1")
 
-    cd $BUILD_WORKSPACE_DIRECTORY
+    cd "$BUILD_WORKSPACE_DIRECTORY"
     git describe --tags --abbrev=0 --always \
-    | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix=`git rev-parse --show-toplevel`/ % -- '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
-    | xargs -r $CLANG_FORMAT_BIN -i --style=file:$CLANG_FORMAT_CONFIG
+    | xargs -rI % git diff --diff-filter=ACMRTUXB --name-only --line-prefix="$(git rev-parse --show-toplevel)"/ % -- '*.[ch]' '*.cpp' '*.cxx' '*.cc' '*.hpp' '*.hxx' \
+    | xargs -r "$CLANG_FORMAT_BIN" -i --style=file:"$CLANG_FORMAT_CONFIG"
 }
 
 check_file() {
@@ -28,14 +28,14 @@ check_file() {
 
     # .clang-format config file has to be placed in the current working directory
     if [ ! -f ".clang-format" ]; then
-        ln -s $CONFIG .clang-format
+        ln -s "$CONFIG" .clang-format
     fi
 
-    $CLANG_FORMAT_BIN $INPUT --dry-run -Werror > $OUTPUT
+    $CLANG_FORMAT_BIN "$INPUT" --dry-run -Werror > "$OUTPUT"
 }
 
 ARG=$1
-CLANG_FORMAT_BIN=$(realpath $2)
+CLANG_FORMAT_BIN=$(realpath "$2")
 shift 2
 
 if [ "$ARG" == "format_diff" ]; then


### PR DESCRIPTION
The clang-format logic relied on copying the config file into the repo root, which pollutes the repository and might fail if there is already a symlink. This change modifies the logic to directly pass the config location to the `clang-format` CLI.

Tested in `starling-core`:
```
bazel run @rules_swiftnav//clang_format
INFO: Analyzed target @rules_swiftnav//clang_format:clang_format (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @rules_swiftnav//clang_format:clang_format up-to-date:
  bazel-bin/external/rules_swiftnav/clang_format/clang_format
INFO: Elapsed time: 0.255s, Critical Path: 0.12s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/external/rules_swiftnav/clang_format/clang_format format_diff external/aarch64-darwin-llvm/bin/clang-format external/rules_swiftnav/clang_format/.clang-format

```