### PR TITLE
Fix bug that resulted in empty linker flags on MacOS [AP-3221]

### DIFF
--- a/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/unix_cc_toolchain_config.bzl
@@ -298,7 +298,7 @@ def _impl(ctx):
                 ] if ctx.attr.opt_link_flags else []),
                 with_features = [with_feature_set(features = ["opt"])],
             ),
-        ] + [flag_set(
+        ] + ([flag_set(
             actions = all_link_actions + lto_index_actions,
             flag_groups = ([
                 flag_group(
@@ -312,7 +312,7 @@ def _impl(ctx):
                 ),
             ]),
             with_features = [with_feature_set(features = ["libcpp"])],
-        )] if is_linux else [],
+        )] if is_linux else []),
     )
 
     dbg_feature = feature(name = "dbg")


### PR DESCRIPTION
In `9b5d663`, a bug was introduced that resulted in empty linker flags
on MacOS. In Starlark, `[a] + [b] if c else []` results in `[]`, if `c` is False. To
just make `[b]` conditional, parenthesis must be used: `[a] + ([b] if c
else [])`.