### PR TITLE
Add symbolizer paths for UBSAN, MSAN, TSAN [AP-3257]

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -114,8 +114,18 @@ def _symbolizer_env(val):
     return select({
         # The + operator is not supported on dict and select types so we need to be
         # clever here.
-        Label("//cc:enable_symbolizer_x86_64_linux"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)"}),
-        Label("//cc:enable_symbolizer_x86_64_darwin"): dict(val, **{"ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)"}),
+        Label("//cc:enable_symbolizer_x86_64_linux"): dict(val, **{
+            "ASAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)",
+            "UBSAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)",
+            "MSAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)",
+            "TSAN_SYMBOLIZER_PATH": "$(location @x86_64-linux-llvm//:symbolizer)",
+        }),
+        Label("//cc:enable_symbolizer_x86_64_darwin"): dict(val, **{
+            "ASAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)",
+            "UBSAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)",
+            "MSAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)",
+            "TSAN_SYMBOLIZER_PATH": "$(location @x86_64-darwin-llvm//:symbolizer)",
+        }),
         "//conditions:default": {},
     })
 


### PR DESCRIPTION
With this change, UBSAN failures in CI should now have symbol information, facilitating hunting done these issues:

```
[----------] 5 tests from ValidatorTest
[ RUN      ] ValidatorTest.FailsWithSanityChecker
external/starling-core/public_types/include/public_types/optional/optional_object.h:904:46: runtime error: load of value 48, which is not a valid value for type 'bool'
error: failed to decompress '.debug_aranges', zlib is not available
error: failed to decompress '.debug_info', zlib is not available
error: failed to decompress '.debug_abbrev', zlib is not available
error: failed to decompress '.debug_line', zlib is not available
error: failed to decompress '.debug_str', zlib is not available
error: failed to decompress '.debug_loc', zlib is not available
error: failed to decompress '.debug_ranges', zlib is not available
    #0 0x1576c5c in swift::optional<double>::operator=(swift::optional<double>&&) /proc/self/cwd/external/starling-core/public_types/include/public_types/optional/optional_object.h
    #1 0x185142c in sensorfusion::InertialNavigationSystem::CorrectedInertialData::operator=(sensorfusion::InertialNavigationSystem::CorrectedInertialData&&) /proc/self/cwd/sensorfusion/include/sensorfusion/deadreckoning/inertial_navigation_system.h:49:10
    #2 0x1851386 in sensorfusion::InertialNavigationSystem::InertialState::operator=(sensorfusion::InertialNavigationSystem::InertialState&&) /proc/self/cwd/sensorfusion/include/sensorfusion/deadreckoning/inertial_navigation_system.h:70:10
    #3 0x1ac4f8d in sensorfusion::InertialNavigationSystem::reset() /proc/self/cwd/sensorfusion/src/deadreckoning/inertial_navigation_system.cc:37:19
    #4 0x1a0a2fd in sensorfusion::ErrorEstimator::reset_filter() /proc/self/cwd/sensorfusion/src/deadreckoning/error_ekf.cc:130:9
    #5 0x1a09919 in sensorfusion::ErrorEstimator::ErrorEstimator(sensorfusion::configuration::Configuration const&, sensorfusion::InertialNavigationSystem*) /proc/self/cwd/sensorfusion/src/deadreckoning/error_ekf.cc:51:3
    #6 0x1916708 in (anonymous namespace)::ValidatorTest::ValidatorTest() /proc/self/cwd/sensorfusion/test/unit/test_sanity_checkers.cc:48:9
    #7 0x19165c0 in (anonymous namespace)::ValidatorTest_FailsWithSanityChecker_Test::ValidatorTest_FailsWithSanityChecker_Test() /proc/self/cwd/sensorfusion/test/unit/test_sanity_checkers.cc:256:1
    #8 0x19165c0 in testing::internal::TestFactoryImpl<(anonymous namespace)::ValidatorTest_FailsWithSanityChecker_Test>::CreateTest() /proc/self/cwd/external/gtest/googletest/include/gtest/internal/gtest-internal.h:472:44
    #9 0x1de353c in testing::Test* testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /proc/self/cwd/external/gtest/googletest/src/gtest.cc:2607:10
    #10 0x1de353c in testing::Test* testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::TestFactoryBase, testing::Test*>(testing::internal::TestFactoryBase*, testing::Test* (testing::internal::TestFactoryBase::*)(), char const*) /proc/self/cwd/external/gtest/googletest/src/gtest.cc:2643:14
    #11 0x1dd068d in testing::TestInfo::Run() /proc/self/cwd/external/gtest/googletest/src/gtest.cc:2851:22
    #12 0x1dd1106 in testing::TestSuite::Run() /proc/self/cwd/external/gtest/googletest/src/gtest.cc:3015:28
    #13 0x1ddd5f8 in testing::internal::UnitTestImpl::RunAllTests() /proc/self/cwd/external/gtest/googletest/src/gtest.cc:5855:44
    #14 0x1de458c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/gtest/googletest/src/gtest.cc:2607:10
    #15 0x1de458c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /proc/self/cwd/external/gtest/googletest/src/gtest.cc:2643:14
    #16 0x1ddcfd2 in testing::UnitTest::Run() /proc/self/cwd/external/gtest/googletest/src/gtest.cc:5438:10
    #17 0x1cf80f8 in RUN_ALL_TESTS() /proc/self/cwd/external/gtest/googletest/include/gtest/gtest.h:2490:46
    #18 0x1cf80f8 in (anonymous namespace)::test_runner(void*) /proc/self/cwd/starling_test_support/src/main.cc:43:18
    #19 0x1cf80f8 in (anonymous namespace)::run_tests() /proc/self/cwd/starling_test_support/src/main.cc:80:5
    #20 0x1cf8065 in main /proc/self/cwd/starling_test_support/src/main.cc:95:16
    #21 0x7fffff488d09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x23d09) (BuildId: 2b86a1968781038c0766b17c1ea11a2a71d7d907)
    #22 0x1541e89 in _start (/home/jenkins/.cache/bazel/_bazel_jenkins/4535647fbb1b448ea04035fc06e4558a/execroot/starling/bazel-out/k8-dbg-ubsan/bin/sensorfusion/sensorfusion_unit_test+0x1541e89) (BuildId: 84737abdebf3f7092985f88abda709e0)
```