### PR TITLE
Llvm: Remove `-fstack-protector` compiler flag [AP-3388]

### DIFF
--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -44,7 +44,6 @@ def cc_toolchain_config(
         "--target=" + target_system_name,
         # Security
         "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-        "-fstack-protector",
         "-fno-omit-frame-pointer",
         # Math
         # This controls whether the compiler allows contracting floating point operations.


### PR DESCRIPTION
In the LLVM toolchain configuration, the stack protector flag is removed. This feature will emit a warning, if stack protection is not deemed sensible for an array, which is the case for less than 8 bytes of size. If warnings as errors is enabled, this will fail the build, if an array of that size is defined.
We are removing the flag for our default builds, as stack protection comes at a small runtime cost and we expect this default toolchain to be used for development purposes only, where stack protection might not be as relevant.
Users are encouraged to consider the stricter flags `-fstack-protector-strong` or `-fstack-protector-all` for production builds.