### PR TITLE
auk: update rules_swiftnav, and clang-format [OI-2284]

### DIFF
--- a/clang_format/.clang-format
+++ b/clang_format/.clang-format
@@ -24,7 +24,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:   
+BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -59,12 +59,12 @@ DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros:   
+ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
 IncludeBlocks:   Preserve
-IncludeCategories: 
+IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2
   - Regex:           '^<.*\.h>'


### PR DESCRIPTION
Jira
- https://swift-nav.atlassian.net/browse/OI-2284

Design Notes
Deleted extra spaces in the `rules_swiftnav/clang_format/.clang-format` file.