### PR TITLE
clang-tidy: Fix class member naming checks

### DIFF
--- a/clang_tidy/.clang-tidy
+++ b/clang_tidy/.clang-tidy
@@ -239,7 +239,7 @@ CheckOptions:
   - key: readability-identifier-naming.ClassMemberCase
     value: lower_case
   - key: readability-identifier-naming.ClassMemberSuffix
-    value: _
+    value: ""
   - key: readability-identifier-naming.ConstantVariableCase
     value: CamelCase
   - key: readability-identifier-naming.ConstantVariablePrefix
@@ -269,7 +269,9 @@ CheckOptions:
   - key: readability-identifier-naming.PrivateMemberSuffix
     value: _
   - key: readability-identifier-naming.ProtectedMemberSuffix
-    value: _
+    value: ""
+  - key: readability-identifier-naming.PublicMemberSuffix
+    value: ""
   - key: readability-identifier-naming.StaticConstantCase
     value: CamelCase
   - key: readability-identifier-naming.StaticConstantPrefix


### PR DESCRIPTION
Our guidelines are, that public and protected class members are snake_case without suffix. Only private members have a `_` suffix.
Tested locally.