### PR TITLE
Update protobuf to v25.1

### DIFF
--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -122,6 +122,34 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+# Globally sets the default C++ version, even for third-party libraries
+string_flag(
+    name = "global_cxx_standard",
+    build_setting_default = "",  #inactive by default
+    visibility = ["//visibility:public"],
+)
+
+# Enable with --@rules_swiftnav//:global_cxx_standard=17
+config_setting(
+    name = "global_cxx17",
+    flag_values = {":global_cxx_standard": "17"},
+    visibility = ["//visibility:public"],
+)
+
+# Enable with --@rules_swiftnav//:global_cxx_standard=20
+config_setting(
+    name = "global_cxx20",
+    flag_values = {":global_cxx_standard": "20"},
+    visibility = ["//visibility:public"],
+)
+
+# Enable with --@rules_swiftnav//:global_cxx_standard=23
+config_setting(
+    name = "global_cxx23",
+    flag_values = {":global_cxx_standard": "23"},
+    visibility = ["//visibility:public"],
+)
+
 bool_flag(
     name = "enable_symbolizer",
     build_setting_default = False,

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -77,10 +77,12 @@ def cc_toolchain_config(
         "-fdata-sections",
     ]
 
-    cxx_flags = [
-        # The whole codebase should build with c++14
-        "-std=c++14",
-    ]
+    cxx_flags = select({
+        "//cc:global_cxx17": ["-std=c++17"],
+        "//cc:global_cxx20": ["-std=c++20"],
+        "//cc:global_cxx23": ["-std=c++23"],
+        "//conditions:default": ["-std=c++14"],
+    })
 
     link_flags = [
         "--target=" + target_system_name,


### PR DESCRIPTION
# Changes

I'm adding a new build flag which controls what C++ version it will use across the entire codebase, including third party libraries. By default Bazel uses C++14 (implicitly, even in third party libraries), which normally won't be a problem if it wasn't for the fact that the newest protobuf library which we are introducing didn't have have a problem with this, specifically Abseil.

Repositories can now run:

```sh
$ bazel build --@rules_swiftnav//:global_cxx_standard=17 //...
```

Which compiles everything with the C++17 standard. Options for C++20 and C++23 have been added as well.
