### PR TITLE
Cleanup toolchain wrapper files [IO-410]

### DIFF
--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64_linux_gcc_arm_embedded_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~x86_64_linux_gcc_arm_embedded_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64_linux_gcc_arm_embedded_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/gcc_arm_gnu_8_3_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~gcc_arm_gnu_8_3_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~gcc_arm_gnu_8_3_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-darwin-llvm/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~aarch64-darwin-llvm/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-darwin-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~x86_64-linux-llvm/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod=external/rules_swiftnav\~\~swift_cc_toolchain_extension\~llvm_mingw_toolchain/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -10,7 +10,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-# Locates the actual tool paths relative to the location this script is 
+# Locates the actual tool paths relative to the location this script is
 # executed from.
 #
 # This is necessary because we download the toolchain using
@@ -28,7 +28,7 @@
 
 set -e
 
-# Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
+# Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
 if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
   set -x
 fi


### PR DESCRIPTION
https://github.com/swift-nav/rules_swiftnav/pull/157 has some leftover cleanup tasks for the toolchain wrapper files.

The changes affect only the Bazel 7 `bzl_mod` build and a test PR is linked.