### PR TITLE
Windows toolchain fix [IO-410]

### DIFF
--- a/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
+++ b/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
@@ -52,14 +52,6 @@ filegroup(
 )
 
 filegroup(
-    name = "dwp_files",
-    srcs = [
-        ":wrappers",
-        "@llvm_mingw_toolchain//:dwp",
-    ],
-)
-
-filegroup(
     name = "linker_files",
     srcs = [
         ":wrappers",


### PR DESCRIPTION
Similar to https://github.com/swift-nav/rules_swiftnav/pull/157, some more files need to be cleaned up (`dwp_files`). While this might work with WORKSPACE, the build fails when using `bzl_mod`.

This changes is tested in:
- [x] starling-core as `WORKSPACE`
- [x] starling-core as `bzl_mod`