### PR TITLE
Implement bzl_mod compatible workaround for local_includes [IO-416]

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -78,8 +78,8 @@ def _common_cxx_opts(exceptions = False, rtti = False, standard = None):
     }) + _common_cxx_standard_opts(standard)
 
 # Handle various nuances of local include paths
-def _construct_local_includes(local_includes):
-    return [construct_local_include(path) for path in local_includes]
+def _construct_local_includes(target_name, local_includes):
+    return [construct_local_include(target_name, path) for path in local_includes]
 
 # Handle whether to link statically
 def _link_static(linkstatic = True):
@@ -232,7 +232,7 @@ def swift_c_library(**kwargs):
     _create_srcs(**kwargs)
     _create_hdrs(**kwargs)
 
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
 
@@ -284,7 +284,7 @@ def swift_cc_library(**kwargs):
     _create_srcs(**kwargs)
     _create_hdrs(**kwargs)
 
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
 
@@ -331,7 +331,7 @@ def swift_c_tool_library(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
 
@@ -377,7 +377,7 @@ def swift_cc_tool_library(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
 
@@ -421,7 +421,7 @@ def swift_c_binary(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
 
@@ -471,7 +471,7 @@ def swift_cc_binary(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
 
@@ -598,7 +598,7 @@ def swift_cc_test_library(**kwargs):
 
     _ = kwargs.pop("nocopts", [])  # To handle API compatibility.
 
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     kwargs["copts"] = local_includes + kwargs.get("copts", [])
 
@@ -650,7 +650,7 @@ def swift_cc_test(name, type, **kwargs):
     if not (type == UNIT or type == INTEGRATION):
         fail("The 'type' attribute must be either UNIT or INTEGRATION")
 
-    local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    local_includes = _construct_local_includes(kwargs.get("name", ""), kwargs.pop("local_includes", []))
 
     kwargs["copts"] = local_includes + kwargs.get("copts", []) + _tests_warn_deprecated_declarations() + _common_cxx_standard_opts(kwargs.pop("standard", []))
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()

--- a/cc/utils.bzl
+++ b/cc/utils.bzl
@@ -8,7 +8,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-def construct_local_include(path):
+def construct_local_include(target_name, path):
     """Helper to correctly set up local (non-public) include paths.
 
     When a bazel workspace is consumed externally, (i.e. via local_repository),
@@ -19,13 +19,18 @@ def construct_local_include(path):
     building a workpace standalone, and externally.
 
     Args:
+        name: The target, which calls this macro
+
         path: The include path relative to the package this macro is called from
 
             Use the special argument $(GENDIR) to construct an include path for
             any generated files the build depends on. Assumes these files are
             not generated into a subdirectory.
     """
-    root = Label(native.repository_name() + "//:WORKSPACE").workspace_root or "."
+    if target_name != "":
+        root = Label(target_name).workspace_root or "."
+    else:
+        root = "."
     package = native.package_name()
 
     # Generated files are placed in $(GENDIR)/external/<workspace_root>


### PR DESCRIPTION
The expression `Label(native.repository_name() + "//:WORKSPACE")` is malformed when using `bzl_mod`. Replacing it by `Label(target_name)` is compatible with both `WORKSPACE` and the `bzl_mod`.

The backwards compatibility to WORKSPACE (Bazel 6) is kept and tested as follows (see also linked PRs):
- [ ] starling-core as bzl_mod (Bazel 7)
- [ ] starling-core as WORKSPACE
- [ ] starling as WORKSPACE
- [ ] orion-engine as WORKSPACE
- [ ] orion as WORKSPACE