### PR TITLE
Wrapper fixes for rules_foreign_cc

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 
 module(
     name = "rules_swiftnav",
-    version = "0.1.0",
+    version = "0.2.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -43,21 +43,22 @@ use_repo(
     "x86_64_linux_gcc_arm_embedded_toolchain",
 )
 
-register_toolchains(
-    "@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin",
-    "@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin",
-    "@rules_swiftnav//cc/toolchains/llvm/aarch64-linux:cc-toolchain-aarch64-linux",
-    "@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux",
-    "@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-intel-mkl",
-    "@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton2",
-    "@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton3",
-    "@rules_swiftnav//cc/toolchains/musl/aarch64:toolchain",
-    "@rules_swiftnav//cc/toolchains/musl/armhf:toolchain",
-    "@rules_swiftnav//cc/toolchains/musl/x86_64:toolchain",
-    "@rules_swiftnav//cc/toolchains/llvm_x86_64_windows:mingw_toolchain",
-    "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain",
-    "@rules_swiftnav//cc/toolchains/yocto_generic:toolchain",
-)
+# On consumer side, register toolchains for the supported architectures:
+# register_toolchains(
+#     "@rules_swiftnav//cc/toolchains/llvm/aarch64-darwin:cc-toolchain-aarch64-darwin",
+#     "@rules_swiftnav//cc/toolchains/llvm/x86_64-darwin:cc-toolchain-x86_64-darwin",
+#     "@rules_swiftnav//cc/toolchains/llvm/aarch64-linux:cc-toolchain-aarch64-linux",
+#     "@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-x86_64-linux",
+#     "@rules_swiftnav//cc/toolchains/llvm/x86_64-linux:cc-toolchain-intel-mkl",
+#     "@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton2",
+#     "@rules_swiftnav//cc/toolchains/llvm/x86_64-aarch64-linux:cc-toolchain-aarch64-bullseye-graviton3",
+#     "@rules_swiftnav//cc/toolchains/musl/aarch64:toolchain",
+#     "@rules_swiftnav//cc/toolchains/musl/armhf:toolchain",
+#     "@rules_swiftnav//cc/toolchains/musl/x86_64:toolchain",
+#     "@rules_swiftnav//cc/toolchains/llvm_x86_64_windows:mingw_toolchain",
+#     "@rules_swiftnav//cc/toolchains/gcc_arm_embedded:toolchain",
+#     "@rules_swiftnav//cc/toolchains/yocto_generic:toolchain",
+# )
 
 yocto_generic_ext = use_extension("@rules_swiftnav//cc/toolchains/yocto_generic:yocto_generic_extension.bzl", "yocto_generic_extension")
 use_repo(yocto_generic_ext, "yocto_generic")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -70,7 +70,7 @@
   "moduleExtensions": {
     "//cc:extensions.bzl%swift_cc_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "owZnzd3iM7No2MXr1OBoOjK6Bcqw0fJm965uaoQOOA0=",
+        "bzlTransitiveDigest": "znaZSUcCcLiSKWaNXYgIV48LbAb5o709DZwDQPkDEXs=",
         "usagesDigest": "JO/wENMiKsORO6Z0Y/QsQqhEvjxGVTXaD62oIR5ovYM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -138,6 +138,45 @@
               "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang%2Bllvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
               "strip_prefix": "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04",
               "sha256": "61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5"
+            }
+          },
+          "aarch64-darwin-llvm20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@//cc/toolchains/llvm20:llvm.BUILD.bzl",
+              "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-macOS-ARM64.tar.xz",
+              "strip_prefix": "LLVM-20.1.7-macOS-ARM64"
+            }
+          },
+          "x86_64-darwin-llvm20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@//cc/toolchains/llvm20:llvm.BUILD.bzl",
+              "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-macOS-X64.tar.xz",
+              "strip_prefix": "LLVM-20.1.7-macOS-X64",
+              "sha256": "8494c98a774051a40bfe1187a2d6442f4bc107598998bbe1673d9bb1572cfd6f"
+            }
+          },
+          "aarch64-linux-llvm20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@//cc/toolchains/llvm20:llvm.BUILD.bzl",
+              "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-Linux-ARM64.tar.xz",
+              "strip_prefix": "LLVM-20.1.7-Linux-ARM64",
+              "sha256": "832f2802a29457dc758f56e26e98558c6cd0e45fcd07186f540cb6e7f4e59385"
+            }
+          },
+          "x86_64-linux-llvm20": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file": "@@//cc/toolchains/llvm20:llvm.BUILD.bzl",
+              "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.7/LLVM-20.1.7-Linux-X64.tar.xz",
+              "strip_prefix": "LLVM-20.1.7-Linux-X64",
+              "sha256": "8494c98a774051a40bfe1187a2d6442f4bc107598998bbe1673d9bb1572cfd6f"
             }
           },
           "aarch64-sysroot": {

--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/gcc_arm_embedded/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -39,15 +39,14 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-darwin-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-darwin-llvm/bin"
 
-echo "DEBUG:"
-echo "pwd: $(pwd)"
-echo "toolchain_bindir_as_bzlmod: ${toolchain_bindir_as_bzlmod}"
-echo "tool: ${tool_name}"
-echo "DEBUG_END"
-
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -57,10 +56,6 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-
-  echo "FOOOO"
-  echo "${BASH_SOURCE[0]}"
-  echo "CXC"
 
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
 
@@ -77,9 +72,6 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   then
     exec "${tool_as_bzlmod}" "${@}"
   fi
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
-  # We're running under _execroot_, call the real tool.
-  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -39,12 +39,15 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-darwin-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-darwin-llvm/bin"
 
+echo "DEBUG:"
+echo "pwd: $(pwd)"
+echo "toolchain_bindir_as_bzlmod: ${toolchain_bindir_as_bzlmod}"
+echo "tool: ${tool_name}"
+echo "DEBUG_END"
+
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
-  # We're running under _execroot_, call the real tool.
-  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -54,9 +57,29 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  echo "FOOOO"
+  echo "${BASH_SOURCE[0]}"
+  echo "CXC"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -51,7 +51,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -35,22 +35,41 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-linux-llvm/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-linux-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/aarch64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -38,7 +38,12 @@ toolchain_bindir=external/x86_64-linux-llvm/bin
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -48,9 +53,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -50,7 +50,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
@@ -50,7 +50,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
@@ -38,7 +38,12 @@ toolchain_bindir=external/x86_64-darwin-llvm/bin
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -48,9 +53,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -43,6 +43,10 @@ if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -68,10 +72,6 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   then
     exec "${tool_as_bzlmod}" "${@}"
   fi
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
-  # We're running under _execroot_, call the real tool.
-  # Use-case: bazelmod
-  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -41,10 +41,8 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
-  # We're running under _execroot_, call the real tool.
-  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
@@ -54,9 +52,26 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -51,12 +53,25 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/aarch64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
@@ -53,7 +53,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 

--- a/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
@@ -41,9 +41,11 @@ toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extensio
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
 elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
@@ -54,9 +56,22 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -35,22 +35,41 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-linux-musl/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-linux-musl/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/x86_64/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/musl/aarch64/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -35,22 +35,41 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/arm-linux-musleabihf/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~arm-linux-musleabihf/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/armhf/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/musl/armhf/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -35,22 +35,41 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/x86_64-linux-musl/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-musl/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.
+  # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
+elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  # We're running under _execroot_, call the real tool.
+  # Use-case: bazelmod
+  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
   #
   # To deal with this we find the tool relative to this script, which is at
-  # _execroot_/external/rules_swiftnav/cc/toolchain/musl/x86_64/wrappers/wrapper.
+  # _execroot_/external/rules_swiftnav/cc/toolchains/musl/x86_64/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+
+  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+
+  # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  then
+    exec "${tool}" "${@}"
+  fi
+
+  # After bazelmod migration, the directory structure is different
+  tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
+  if [[ -f "${tool_as_bzlmod}" ]];
+  then
+    exec "${tool_as_bzlmod}" "${@}"
+  fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5


### PR DESCRIPTION
* `MODULE` does not need to register all those toolchains, because the consumer has to do it.
* wrapper files have been adapted to support `rules_foreign_cc` used with `bzl_mod`.

Tested in
- [x] orion (`WORKSPACE`)
- [x] starling (`WORKSPACE`)
- [x] libsbp (`MODULE`)