### PR TITLE
Provide Bazel 8 compatibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 
 module(
     name = "rules_swiftnav",
-    version = "0.2.0",
+    version = "0.3.0",
     compatibility_level = 1,
 )
 

--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64_linux_gcc_arm_embedded_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64_linux_gcc_arm_embedded_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64_linux_gcc_arm_embedded_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/gcc_arm_gnu_8_3/BUILD.bazel
+++ b/cc/toolchains/gcc_arm_gnu_8_3/BUILD.bazel
@@ -86,7 +86,7 @@ filegroup(
 config(
     name = "config",
     sysroot = select({
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav~~swift_cc_toolchain_extension~gcc_arm_gnu_8_3_toolchain/aarch64-linux-gnu/libc",
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+gcc_arm_gnu_8_3_toolchain/aarch64-linux-gnu/libc",
         "//conditions:default": "external/gcc_arm_gnu_8_3_toolchain/aarch64-linux-gnu/libc",
     }),
 )

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/gcc_arm_gnu_8_3_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~gcc_arm_gnu_8_3_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+gcc_arm_gnu_8_3_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-darwin-llvm/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-darwin-llvm/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-darwin-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm/llvm.BUILD.bzl
+++ b/cc/toolchains/llvm/llvm.BUILD.bzl
@@ -15,7 +15,7 @@ exports_files(glob([
     "bin/*",
     "lib/*",
     "include/*",
-]))
+], allow_empty = True))
 
 ## LLVM toolchain files
 
@@ -36,7 +36,7 @@ filegroup(
         "bin/ld.lld",
         # Required on mac
         "bin/ld64.lld",
-    ]),
+    ], allow_empty = True),
 )
 
 filegroup(
@@ -49,7 +49,7 @@ filegroup(
 
 filegroup(
     name = "bin",
-    srcs = glob(["bin/**"]),
+    srcs = glob(["bin/**"], allow_empty = True),
 )
 
 filegroup(
@@ -66,6 +66,7 @@ filegroup(
             "lib/libclang*.a",
             "lib/liblld*.a",
         ],
+        allow_empty = True,
     ),
     # Do not include the .dylib files in the linker sandbox because they will
     # not be available at runtime. Any library linked from the toolchain should

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -118,7 +118,7 @@ cc_toolchain_config(
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
         # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-sysroot",
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
         "//conditions:default": "external/x86_64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-llvm/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
+++ b/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
@@ -91,7 +91,7 @@ filegroup(
 config(
     name = "config",
     sysroot = select({
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain",
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain",
         "//conditions:default": "external/llvm_mingw_toolchain",
     }),
 )

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~llvm_mingw_toolchain/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.


### PR DESCRIPTION
In order to use Bazel 8 following changes are needed:
* empty `globs` are marked `allow_empty`
* `+` instead of `~` as `bzl_mod` path seperator (backwards compatibility to Bazel 7 can be achieved using `--incompatible_use_plus_in_repo_names`)

Tested in
- [x] starling-core (Bazel 6)
- [x] starling-core (Bazel 7)
- [x] starling-core (Bazel 8)