### PR TITLE
More Bazel 8 compatibility

### DIFF
--- a/cc/toolchains/gcc_arm_embedded/BUILD.bazel
+++ b/cc/toolchains/gcc_arm_embedded/BUILD.bazel
@@ -115,6 +115,10 @@ config(
             "//conditions:default": [],
         },
     ),
+    sysroot = select({
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+gcc_arm_embedded_toolchain",
+        "//conditions:default": "external/gcc_arm_embedded_toolchain",
+    }),
 )
 
 cc_toolchain(

--- a/cc/toolchains/gcc_arm_embedded/config.bzl
+++ b/cc/toolchains/gcc_arm_embedded/config.bzl
@@ -80,7 +80,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/gcc_arm_embedded_toolchain",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-no-canonical-prefixes",
                                 "-fno-canonical-system-headers",
                                 "-fno-common",
@@ -167,6 +167,7 @@ config = rule(
     attrs = {
         "c_opts": attr.string_list(),
         "link_opts": attr.string_list(),
+        "sysroot": attr.string(),
     },
     provides = [CcToolchainConfigInfo],
 )

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -35,7 +35,7 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-linux-llvm/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-linux-llvm/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-darwin-llvm20/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-darwin-llvm20/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-darwin-llvm20/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-linux-llvm20/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-linux-llvm20/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-llvm20/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
@@ -103,7 +103,7 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-sysroot",
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
         "//conditions:default": "external/aarch64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm20/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-llvm20/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm20/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-darwin-llvm20/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-darwin-llvm20/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-darwin-llvm20/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
@@ -118,7 +118,7 @@ cc_toolchain_config(
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
         # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-sysroot",
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
         "//conditions:default": "external/x86_64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
@@ -37,7 +37,7 @@ tool_name=$(basename "${BASH_SOURCE[0]}")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm20/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-llvm20/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm20/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/musl/aarch64/BUILD.bazel
+++ b/cc/toolchains/musl/aarch64/BUILD.bazel
@@ -77,7 +77,13 @@ filegroup(
     tags = ["manual"],
 )
 
-config(name = "config")
+config(
+    name = "config",
+    sysroot = select({
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-musl",
+        "//conditions:default": "external/aarch64-linux-musl",
+    }),
+)
 
 cc_toolchain(
     name = "cc_toolchain",

--- a/cc/toolchains/musl/aarch64/config.bzl
+++ b/cc/toolchains/musl/aarch64/config.bzl
@@ -80,7 +80,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/aarch64-linux-musl",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-no-canonical-prefixes",
                                 "-fno-canonical-system-headers",
                                 "-fno-common",
@@ -120,7 +120,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/aarch64-linux-musl",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",
@@ -152,6 +152,8 @@ def _impl(ctx):
 
 config = rule(
     implementation = _impl,
-    attrs = {},
+    attrs = {
+        "sysroot": attr.string(),
+    },
     provides = [CcToolchainConfigInfo],
 )

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -35,7 +35,7 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/aarch64-linux-musl/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~aarch64-linux-musl/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-musl/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/musl/armhf/BUILD.bazel
+++ b/cc/toolchains/musl/armhf/BUILD.bazel
@@ -77,7 +77,13 @@ filegroup(
     tags = ["manual"],
 )
 
-config(name = "config")
+config(
+    name = "config",
+    sysroot = select({
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+arm-linux-musleabihf",
+        "//conditions:default": "external/arm-linux-musleabihf",
+    }),
+)
 
 cc_toolchain(
     name = "cc_toolchain",

--- a/cc/toolchains/musl/armhf/config.bzl
+++ b/cc/toolchains/musl/armhf/config.bzl
@@ -80,7 +80,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/arm-linux-musleabihf",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-no-canonical-prefixes",
                                 "-fno-canonical-system-headers",
                                 "-fno-common",
@@ -120,7 +120,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/arm-linux-musleabihf",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",
@@ -152,6 +152,8 @@ def _impl(ctx):
 
 config = rule(
     implementation = _impl,
-    attrs = {},
+    attrs = {
+        "sysroot": attr.string(),
+    },
     provides = [CcToolchainConfigInfo],
 )

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -35,7 +35,7 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/arm-linux-musleabihf/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~arm-linux-musleabihf/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+arm-linux-musleabihf/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/musl/x86_64/BUILD.bazel
+++ b/cc/toolchains/musl/x86_64/BUILD.bazel
@@ -77,7 +77,13 @@ filegroup(
     tags = ["manual"],
 )
 
-config(name = "config")
+config(
+    name = "config",
+    sysroot = select({
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-musl",
+        "//conditions:default": "external/x86_64-linux-musl",
+    }),
+)
 
 cc_toolchain(
     name = "cc_toolchain",

--- a/cc/toolchains/musl/x86_64/config.bzl
+++ b/cc/toolchains/musl/x86_64/config.bzl
@@ -80,7 +80,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/x86_64-linux-musl",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-no-canonical-prefixes",
                                 "-fno-canonical-system-headers",
                                 "-fno-common",
@@ -120,7 +120,7 @@ def _impl(ctx):
                     flag_groups = ([
                         flag_group(
                             flags = [
-                                "--sysroot=external/x86_64-linux-musl",
+                                "--sysroot={}".format(ctx.attr.sysroot),
                                 "-Wl,-O1",
                                 "-Wl,--hash-style=gnu",
                                 "-Wl,--as-needed",
@@ -152,6 +152,8 @@ def _impl(ctx):
 
 config = rule(
     implementation = _impl,
-    attrs = {},
+    attrs = {
+        "sysroot": attr.string(),
+    },
     provides = [CcToolchainConfigInfo],
 )

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -35,7 +35,7 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/x86_64-linux-musl/bin
-toolchain_bindir_as_bzlmod="external/rules_swiftnav~~swift_cc_toolchain_extension~x86_64-linux-musl/bin"
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-musl/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.


### PR DESCRIPTION
Follow up on https://github.com/swift-nav/rules_swiftnav/pull/169

In order to use Bazel 8 following changes are needed:
* select proper `sysroot`s for some additional toolchains
* `+` instead of `~` as `bzl_mod` path seperator (backwards compatibility to Bazel 7 can be achieved using `--incompatible_use_plus_in_repo_names`) for some more toolchains

Tested in
- [x] starling-core (Bazel 6)
- [x] starling-core (Bazel 7)
- [x] starling-core (Bazel 8)