### PR TITLE
Fix bzl_mod symlink issues in doxygen rule

### DIFF
--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -20,10 +20,14 @@ def _swift_doxygen_impl(ctx):
 
     # this performs a CMake-like replacement of @VAR@ based on the vars dict
     config = configure_file_impl(ctx, vars, ctx.attr.name + "_Doxyfile")[0].files.to_list()[0]
+    
+    # Create a processed config file for sed operations
+    processed_config = ctx.actions.declare_file(ctx.attr.name + "_processed_Doxyfile")
 
+    # First action: Create the processed config file and apply sed replacements
     ctx.actions.run_shell(
-        inputs = [config] + ctx.files.deps,
-        outputs = [doxygen_out],
+        inputs = [config],
+        outputs = [processed_config],
         env = vars,
         command = """
         DOXYGEN_DOT_FOUND=NO
@@ -36,18 +40,26 @@ def _swift_doxygen_impl(ctx):
 
         PRW=`pwd`
 
-        # backward compatibility with old CMake-style doxygen config files
-        sed -i "s|@DOXYGEN_DOT_FOUND@|$DOXYGEN_DOT_FOUND|g" {config}
-        sed -i "s|@DOXYGEN_DOT_PATH@|$DOXYGEN_DOT_PATH|g" {config}
-        sed -i "s|@PLANTUML_JAR_PATH@|/usr/local/bin/plantuml.jar|g" {config}
-        sed -i "s|@INPUT_DIR@|$PROJECT_SOURCE_DIR|g" {config}
-        sed -i "s|@PROJECT_NAME@|$PROJECT_NAME|g" {config}
-        sed -i "s|@STABLE_GIT_TAG@|$STABLE_GIT_TAG|g" {config}
-        sed -i "s|@DOXYGEN_EXCLUDE@|$DOXYGEN_EXCLUDE|g" {config}
-        sed -i "s|@PROJECT_SOURCE_DIR@|$PRW|g" {config}
+        # Apply backward compatibility sed replacements
+        sed "s|@DOXYGEN_DOT_FOUND@|$DOXYGEN_DOT_FOUND|g" {original_config} | \
+        sed "s|@DOXYGEN_DOT_PATH@|$DOXYGEN_DOT_PATH|g" | \
+        sed "s|@PLANTUML_JAR_PATH@|/usr/local/bin/plantuml.jar|g" | \
+        sed "s|@INPUT_DIR@|$PROJECT_SOURCE_DIR|g" | \
+        sed "s|@PROJECT_NAME@|$PROJECT_NAME|g" | \
+        sed "s|@STABLE_GIT_TAG@|$STABLE_GIT_TAG|g" | \
+        sed "s|@DOXYGEN_EXCLUDE@|$DOXYGEN_EXCLUDE|g" | \
+        sed "s|@PROJECT_SOURCE_DIR@|$PRW|g" > {processed_config}
+        """.format(original_config = config.path, processed_config = processed_config.path),
+    )
 
+    # Second action: Run doxygen with the processed config
+    ctx.actions.run_shell(
+        inputs = [processed_config] + ctx.files.deps,
+        outputs = [doxygen_out],
+        env = vars,
+        command = """
         PATH=$PATH doxygen {config}
-        """.format(config = config.path),
+        """.format(config = processed_config.path),
     )
 
     return [DefaultInfo(files = depset([doxygen_out, config]))]

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -20,7 +20,7 @@ def _swift_doxygen_impl(ctx):
 
     # this performs a CMake-like replacement of @VAR@ based on the vars dict
     config = configure_file_impl(ctx, vars, ctx.attr.name + "_Doxyfile")[0].files.to_list()[0]
-    
+
     # Create a processed config file for sed operations
     processed_config = ctx.actions.declare_file(ctx.attr.name + "_processed_Doxyfile")
 


### PR DESCRIPTION
With the introduction of `bzl_mod` the doxygen rule was broken and needs to be fixed. This means splitting up the preprocessing of doxygen input files into smaller actions.

- [x] Test with Bazel 7 in `orion-engine`
- [x] Test with Bazel 6 in `starling-core`