### PR TITLE
Migrate x86 64 aarch64 linux toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 
 module(
     name = "rules_swiftnav",
-    version = "0.3.0",
+    version = "0.4.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -76,7 +76,7 @@
     "//cc:extensions.bzl%swift_cc_toolchain_extension": {
       "general": {
         "bzlTransitiveDigest": "znaZSUcCcLiSKWaNXYgIV48LbAb5o709DZwDQPkDEXs=",
-        "usagesDigest": "eJT8fw0gfMPpMr0QXJk+/2KyaDk7tWABkSg38EnwwmY=",
+        "usagesDigest": "BqeY+vKftdzwujAL4kqw9tfp/bR/gWuJaOeQtpeBjZc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -290,7 +290,7 @@
     "//cc/toolchains/yocto_generic:yocto_generic_extension.bzl%yocto_generic_extension": {
       "general": {
         "bzlTransitiveDigest": "Q4v/HN5Wh/W0JsPpeExQzSqIslfepuWsd75kvW+25FI=",
-        "usagesDigest": "rq/79ksOx0UzTXiDiNZPMxP/ynuGC96ZKXAp671gmfI=",
+        "usagesDigest": "7kQDxQZ5IqOQabmfswCYPykw+dYufc7fj3KaTEjzrbo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -206,6 +206,15 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "_enable_bzlmod_not_libcpp",
+    flag_values = {
+        ":enable_bzlmod": "true",
+        ":use_libcpp": "false",
+    },
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "fix_include_guards",
     srcs = [

--- a/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
@@ -117,8 +117,8 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
         "//conditions:default": "external/aarch64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -103,8 +103,8 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
         "//conditions:default": "external/aarch64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -101,7 +101,12 @@ cc_toolchain_config(
     name = "local-x86_64-aarch64-linux",
     abi_libc_version = "glibc_unknown",
     abi_version = "clang",
-    builtin_sysroot = "external/aarch64-sysroot",
+    builtin_sysroot = select({
+        "@rules_swiftnav//cc:_use_libcpp": None,
+        # Remove once bzlmod is enabled by default
+        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
+        "//conditions:default": "external/aarch64-sysroot",
+    }),
     compiler = "clang",
     cxx_builtin_include_directories = [
         "%sysroot%/usr/include",

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -35,6 +35,7 @@ fi
 
 tool_name=$(basename "${BASH_SOURCE[0]}")
 toolchain_bindir=external/x86_64-linux-llvm/bin
+toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm/bin"
 
 if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
   # We're running under _execroot_, call the real tool.

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -117,8 +117,8 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
         "//conditions:default": "external/x86_64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm20/aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/aarch64-linux/BUILD.bazel
@@ -117,8 +117,8 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
         "//conditions:default": "external/aarch64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
@@ -102,8 +102,9 @@ cc_toolchain_config(
     abi_libc_version = "glibc_unknown",
     abi_version = "clang",
     builtin_sysroot = select({
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
+        # _use_libcpp case needs to be implemented properly here!
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-sysroot",
         "//conditions:default": "external/aarch64-sysroot",
     }),
     compiler = "clang",

--- a/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
@@ -117,8 +117,8 @@ cc_toolchain_config(
     abi_version = "clang",
     builtin_sysroot = select({
         "@rules_swiftnav//cc:_use_libcpp": None,
-        # Remove once bzlmod is enabled by default
-        "@rules_swiftnav//cc:_enable_bzlmod": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
+        # When bzlmod is enabled but libcpp is not, use the bzlmod path
+        "@rules_swiftnav//cc:_enable_bzlmod_not_libcpp": "external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-sysroot",
         "//conditions:default": "external/x86_64-sysroot",
     }),
     compiler = "clang",


### PR DESCRIPTION
 - Migrate x86 64 aarch64 linux toolchain to be compliant with `bzl_mod`
 - The `sysroot`s for `clang` toolchain have been changed accordingly to select `None` when both `bzl_mod` and `libcpp` are enabled. Else if `bzl_mod` and not `libcpp`, returns the proper `bzl_mod`-compliant directory, else the non-`bzl_mod`-compliant directory.

Tested in:
- [x] orion (Bazel 6)
- [x] orion (Bazel 7)
- [x] orion-engine (Bazel 6)
- [x] orion-engine (Bazel 7)
- [x] starling-core (Bazel 6, 7, 8)
- [x] starling (Bazel 6)