### PR TITLE
Make cereal thread safe by default

### DIFF
--- a/third_party/cereal.BUILD
+++ b/third_party/cereal.BUILD
@@ -15,5 +15,7 @@ package(
 cc_library(
     name = "cereal",
     hdrs = glob(["include/**"]),
+    defines = ["CEREAL_THREAD_SAFE=1"],
     includes = ["include"],
+    linkopts = ["-lpthread"],
 )


### PR DESCRIPTION
# Changes

If you read the [Cereal library documentation](https://uscilab.github.io/cereal/thread_safety.html), you will be shocked that the default behavior for the library is to not have it run in a multithreaded manner. It apparently has a global variable that it uses to track information and it works nicely in a single threaded application, however in a mutlithreaded application is can be problematic.

The changes here changes the default behavior so that this global variable is thread safe and doesn't cause any undefined behavior.