### PR TITLE
have cc toolchain wrappers use posix shell

### DIFF
--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64_linux_gcc_arm_embedded_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64_linux_gcc_arm_embedded_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
-  exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+  exec "${toolchain_bindir}/${tool_name}" "$@"
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
-  exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+  exec "${toolchain_bindir_as_bzlmod}/${tool_name}" "$@"
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,18 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
-  then
-    exec "${tool}" "${@}"
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]; then
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
-  then
-    exec "${tool_as_bzlmod}" "${@}"
+  if [ -f "${tool_as_bzlmod}" ]; then
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/gcc_arm_gnu_8_3_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+gcc_arm_gnu_8_3_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,18 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
-  then
-    exec "${tool}" "${@}"
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]; then
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
-  then
-    exec "${tool_as_bzlmod}" "${@}"
+  if [ -f "${tool_as_bzlmod}" ]; then
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-darwin-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-darwin-llvm/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/aarch64-linux-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-llvm/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -55,20 +55,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/x86_64-linux-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -55,20 +55,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,22 +29,22 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/x86_64-darwin-llvm/bin
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -54,20 +54,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-darwin-llvm20/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-darwin-llvm20/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/aarch64-linux-llvm20/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-llvm20/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm20/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm20/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-darwin-llvm20/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-darwin-llvm20/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2025 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,25 +29,25 @@
 set -e
 
 # Use --actionv_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/x86_64-linux-llvm20/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-llvm20/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -57,20 +57,20 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ];
   then
-    exec "${tool}" "${@}"
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
+  if [ -f "${tool_as_bzlmod}" ];
   then
-    exec "${tool_as_bzlmod}" "${@}"
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -54,9 +54,9 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  execroot_path="${0%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -54,9 +54,9 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  execroot_path="${0%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -54,9 +54,9 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # _execroot_/external/rules_swiftnav/cc/toolchain/llvm/x86_64-linux/wrappers/wrapper.
   #
   # If the wrapper is relocated then this line needs to be adjusted.
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
+  execroot_path="${0%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 # In case the tool label is changed, a change in here is very likely needed
 # This establishes backwards compatibility with the old WORKSPACE file
 toolchain_bindir=external/llvm_mingw_toolchain/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+llvm_mingw_toolchain/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif [ "$0" == "/"* ]; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -56,7 +56,7 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # If the wrapper is relocated then this line needs to be adjusted.
   execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}"
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  exec "${tool}" "${@}"
+  exec "${tool}" "$@"
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."
   exit 5

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/aarch64-linux-musl/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+aarch64-linux-musl/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -55,20 +55,18 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
-  then
-    exec "${tool}" "${@}"
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]; then
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
-  then
-    exec "${tool_as_bzlmod}" "${@}"
+  if [ -f "${tool_as_bzlmod}" ]; then
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/arm-linux-musleabihf/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+arm-linux-musleabihf/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -55,20 +55,18 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
-  then
-    exec "${tool}" "${@}"
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]; then
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
-  then
-    exec "${tool_as_bzlmod}" "${@}"
+  if [ -f "${tool_as_bzlmod}" ]; then
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright (C) 2022 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
@@ -29,23 +29,23 @@
 set -e
 
 # Use --action_env=SWIFTNAV_VERBOSE_TOOLCHAIN to enable
-if [[ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]]; then
+if [ -n "$SWIFTNAV_VERBOSE_TOOLCHAIN" ]; then
   set -x
 fi
 
-tool_name=$(basename "${BASH_SOURCE[0]}")
+tool_name=$(basename "$0")
 toolchain_bindir=external/x86_64-linux-musl/bin
 toolchain_bindir_as_bzlmod="external/rules_swiftnav++swift_cc_toolchain_extension+x86_64-linux-musl/bin"
 
-if [[ -f "${toolchain_bindir}"/"${tool_name}" ]]; then
+if [ -f "${toolchain_bindir}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # use-case: WORKSPACE
   exec "${toolchain_bindir}"/"${tool_name}" "$@"
-elif [[ -f "${toolchain_bindir_as_bzlmod}"/"${tool_name}" ]]; then
+elif [ -f "${toolchain_bindir_as_bzlmod}/${tool_name}" ]; then
   # We're running under _execroot_, call the real tool.
   # Use-case: bazelmod
   exec "${toolchain_bindir_as_bzlmod}"/"${tool_name}" "$@"
-elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
+elif case "$0" in /*) true;; *) false;; esac; then
   # This branch exists because some users of the toolchain,
   # namely rules_foreign_cc, will change CWD and call $CC (this script)
   # with its absolute path.
@@ -55,20 +55,18 @@ elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   #
   # If the wrapper is relocated then this line needs to be adjusted.
 
-  execroot_path="${BASH_SOURCE[0]%/*/*/*/*/*/*/*/*}" 
+  execroot_path="${0%/*/*/*/*/*/*/*/*}" 
 
   # Legacy path for non-bazelmod
   tool="${execroot_path}/${toolchain_bindir}/${tool_name}"
-  if [[ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]];
-  then
-    exec "${tool}" "${@}"
+  if [ -f "${execroot_path}/${toolchain_bindir}/${tool_name}" ]; then
+    exec "${tool}" "$@"
   fi
 
   # After bazelmod migration, the directory structure is different
   tool_as_bzlmod="${execroot_path}/${toolchain_bindir_as_bzlmod}/${tool_name}"
-  if [[ -f "${tool_as_bzlmod}" ]];
-  then
-    exec "${tool_as_bzlmod}" "${@}"
+  if [ -f "${tool_as_bzlmod}" ]; then
+    exec "${tool_as_bzlmod}" "$@"
   fi
 else
   >&2 echo "ERROR: could not find ${tool_name}; PWD=\"$(pwd)\"; PATH=\"${PATH}\"."


### PR DESCRIPTION
rules_rust uses the cc toolchain for linking, and I've been running into issues building with rules_rust + our custom toolchain (specifically llvm 20 on mac). Disabling the custom toolchain plus updating cc rules to https://github.com/bazelbuild/rules_cc/pull/466 fixed my issue.

I don't know if this needs to/should be applied to all wrappers, but I figured it couldn't hurt?