### PR TITLE
cc_static_library for mac

### DIFF
--- a/cc/cc_static_library.bzl
+++ b/cc/cc_static_library.bzl
@@ -40,6 +40,38 @@ def _get_commands(output_lib, libs):
     commands.append("end")
     return commands
 
+def _run_ar_mri(ctx, cc_toolchain, script_file, output_lib, libs):
+    ctx.actions.run_shell(
+        command = "{} -M < {}".format(cc_toolchain.ar_executable, script_file.path),
+        inputs = [script_file] + libs + cc_toolchain.all_files.to_list(),
+        outputs = [output_lib],
+        mnemonic = "ArMerge",
+        progress_message = "Merging static library {}".format(output_lib.path),
+    )
+
+def _run_ar_bsd(ctx, cc_toolchain, output_lib, libs):
+    # macOS uses libtool instead of ar for creating static libraries
+    args = ctx.actions.args()
+    if cc_toolchain.ar_executable.endswith("libtool"):
+        args.add("-static")
+        args.add("-o")
+        args.add(output_lib.path)
+        args.add_all(libs)
+    else:
+        # BSD ar doesn't support MRI scripts, so we create the archive manually
+        args.add("rc")  # replace and create
+        args.add(output_lib.path)
+        args.add_all(libs)
+
+    ctx.actions.run(
+        executable = cc_toolchain.ar_executable,
+        arguments = [args],
+        inputs = libs + cc_toolchain.all_files.to_list(),
+        outputs = [output_lib],
+        mnemonic = "ArMerge",
+        progress_message = "Merging static library {}".format(output_lib.path),
+    )
+
 def _cc_static_library_impl(ctx):
     output_lib = ctx.actions.declare_file("{}.a".format(ctx.attr.name))
 
@@ -49,19 +81,18 @@ def _cc_static_library_impl(ctx):
 
     libs = _get_libs(ctx, linker_inputs)
 
-    script_file = ctx.actions.declare_file("{}.mri".format(ctx.attr.name))
-    ctx.actions.write(
-        output = script_file,
-        content = "\n".join(_get_commands(output_lib, libs)) + "\n",
-    )
+    # Use different ar strategies based on platform
+    # GNU ar supports MRI scripts, BSD ar (macOS) does not
+    if ctx.target_platform_has_constraint(ctx.attr._macos_constraint[platform_common.ConstraintValueInfo]):
+        _run_ar_bsd(ctx, cc_toolchain, output_lib, libs)
+    else:
+        script_file = ctx.actions.declare_file("{}.mri".format(ctx.attr.name))
+        ctx.actions.write(
+            output = script_file,
+            content = "\n".join(_get_commands(output_lib, libs)) + "\n",
+        )
+        _run_ar_mri(ctx, cc_toolchain, script_file, output_lib, libs)
 
-    ctx.actions.run_shell(
-        command = "{} -M < {}".format(cc_toolchain.ar_executable, script_file.path),
-        inputs = [script_file] + libs + cc_toolchain.all_files.to_list(),
-        outputs = [output_lib],
-        mnemonic = "ArMerge",
-        progress_message = "Merging static library {}".format(output_lib.path),
-    )
     return [
         DefaultInfo(files = depset([output_lib])),
     ]
@@ -72,6 +103,9 @@ cc_static_library = rule(
         "deps": attr.label_list(),
         "_cc_toolchain": attr.label(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+        ),
+        "_macos_constraint": attr.label(
+            default = "@platforms//os:macos",
         ),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -195,11 +195,6 @@ def cc_static_library(name, deps, visibility = ["//visibility:private"]):
     _cc_static_library(
         name = name,
         deps = deps,
-        target_compatible_with = select({
-            # Creating static libraries is not supported by macos yet.
-            "@platforms//os:macos": ["@platforms//:incompatible"],
-            "//conditions:default": [],
-        }),
         visibility = visibility,
     )
 


### PR DESCRIPTION
Adds mac support to cc_static_library - the issue was that the `ar` that ships with mac doesn't support mir. This change leaves the existing path the same and on mac uses `libtool` or `ar rc` to create the static ilb