### PR TITLE
Bump rules_swiftnav 0.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 
 module(
     name = "rules_swiftnav",
-    version = "0.5.0",
+    version = "0.6.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
# Changes

Tagging latest commit with 0.6.0 version.