### PR TITLE
Add gcc 11 toolchain linux x86_64

### DIFF
--- a/cc/toolchains/gcc_11/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/gcc_11/x86_64-linux/BUILD.bazel
@@ -1,0 +1,99 @@
+load("@rules_cc//cc/private/toolchain:unix_cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@rules_cc//cc/toolchains:cc_toolchain.bzl", "cc_toolchain")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_toolchain_config(
+    name = "local-x86_64-linux",
+    abi_libc_version = "unknown",
+    abi_version = "unknown",
+    compiler = "gcc-11",
+    coverage_compile_flags = ["--coverage"],
+    coverage_link_flags = ["--coverage"],
+    cpu = "k8",
+    cxx_builtin_include_directories = [
+        "/usr/include",
+        "/usr/include/c++/11",
+        "/usr/include/x86_64-linux-gnu/c++/11",
+        "/usr/include/c++/11/backward",
+        "/usr/lib/gcc/x86_64-linux-gnu/11/include",
+        "/usr/lib/gcc/x86_64-linux-gnu/11/include-fixed",
+    ],
+    cxx_flags = ["-std=c++17"],
+    dbg_compile_flags = ["-g"],
+    host_system_name = "local",
+    link_flags = [
+        "-lstdc++",
+        "-fuse-ld=gold",
+        "-Wl,-no-as-needed",
+        "-Wl,-z,relro,-z,now",
+        "-B/usr/bin",
+        "-pass-exit-codes",
+        "-lm",
+    ],
+    opt_compile_flags = [
+        "-g0",
+        "-O2",
+        "-D_FORTIFY_SOURCE=1",
+        "-DNDEBUG",
+        "-ffunction-sections",
+        "-fdata-sections",
+    ],
+    opt_link_flags = ["-Wl,--gc-sections"],
+    supports_start_end_lib = True,
+    target_libc = "glibc",
+    target_system_name = "local",
+    tool_paths = {
+        "ar": "/usr/bin/ar",
+        "as": "/usr/bin/as",
+        "cpp": "/usr/bin/cpp-11",
+        "gcc": "/usr/bin/gcc-11",
+        "g++": "/usr/bin/g++-11",
+        "gcov": "/usr/bin/gcov-11",
+        "ld": "/usr/bin/g++-11",
+        "nm": "/usr/bin/nm",
+        "objcopy": "/usr/bin/objcopy",
+        "objdump": "/usr/bin/objdump",
+        "ranlib": "/usr/bin/ranlib",
+        "strip": "/usr/bin/strip",
+    },
+    toolchain_identifier = "cc-gcc-x86_64-linux",
+    unfiltered_compile_flags = [
+        "-fno-canonical-system-headers",
+        "-Wno-builtin-macro-redefined",
+        "-D__DATE__=\"redacted\"",
+        "-D__TIMESTAMP__=\"redacted\"",
+        "-D__TIME__=\"redacted\"",
+    ],
+)
+
+filegroup(name = "empty")
+
+cc_toolchain(
+    name = "cc-gcc-x86_64-linux",
+    all_files = ":empty",
+    ar_files = ":empty",
+    as_files = ":empty",
+    compiler_files = ":empty",
+    dwp_files = ":empty",
+    linker_files = ":empty",
+    objcopy_files = ":empty",
+    strip_files = ":empty",
+    supports_param_files = 0,
+    toolchain_config = ":local-x86_64-linux",
+    toolchain_identifier = "cc-gcc-x86_64-linux",
+)
+
+toolchain(
+    name = "cc-toolchain-x86_64-linux",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":cc-gcc-x86_64-linux",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)


### PR DESCRIPTION
Implement a `gcc-11` toolchain for Linux `x86_64`.

Tested:
- [x] orion-engine
- [x] orion