### PR TITLE
Add standard argument to `swift_cc_test_library` and `swift_c_test`

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -592,14 +592,15 @@ def swift_cc_test_library(**kwargs):
             be relative to the package this macro is called from.
     """
 
-    _ = kwargs.pop("nocopts", [])  # To handle API compatibility.
 
+    nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
-    exceptions = kwargs.pop("exceptions", False)
-    rtti = kwargs.pop("rtti", False)
+
     standard = kwargs.pop("standard", None)
 
-    cxxopts = _common_cxx_opts(exceptions, rtti, standard)
+    copts = _common_cc_opts(nocopts, pedantic = False)
+    cxxopts = _common_cxx_standard_opts(standard)
+
     kwargs["copts"] = copts + cxxopts + local_includes + kwargs.get("copts", [])
 
     kwargs["tags"] = [TEST_LIBRARY] + kwargs.get("tags", [])

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -592,7 +592,6 @@ def swift_cc_test_library(**kwargs):
             be relative to the package this macro is called from.
     """
 
-
     nocopts = kwargs.pop("nocopts", [])  # pop because nocopts is a deprecated cc* attr.
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -595,8 +595,12 @@ def swift_cc_test_library(**kwargs):
     _ = kwargs.pop("nocopts", [])  # To handle API compatibility.
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
+    exceptions = kwargs.pop("exceptions", False)
+    rtti = kwargs.pop("rtti", False)
+    standard = kwargs.pop("standard", None)
 
-    kwargs["copts"] = local_includes + kwargs.get("copts", [])
+    cxxopts = _common_cxx_opts(exceptions, rtti, standard)
+    kwargs["copts"] = copts + cxxopts + local_includes + kwargs.get("copts", [])
 
     kwargs["tags"] = [TEST_LIBRARY] + kwargs.get("tags", [])
 

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -652,7 +652,10 @@ def swift_c_test(name, type, **kwargs):
 
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
-    kwargs["copts"] = local_includes + kwargs.get("copts", []) + _tests_warn_deprecated_declarations()
+    extensions = kwargs.pop("extensions", False)
+    standard = kwargs.pop("standard", 99)
+
+    kwargs["copts"] = local_includes + kwargs.get("copts", []) + _tests_warn_deprecated_declarations() + _c_standard(extensions, standard)
     kwargs["data"] = kwargs.get("data", []) + _symbolizer_data()
     kwargs["env"] = _symbolizer_env(kwargs.get("env", {}))
     kwargs["linkstatic"] = kwargs.get("linkstatic", True)


### PR DESCRIPTION
`swift_cc_test_library` and `swift_c_test` did not support the `standard` attribute, which allows an explicit selection of the language standard. We want to be able to precisely set the C/C++ standard for all targets. All other swift related rules support this already.

Reviving @armallen's old commits.