### PR TITLE
Add clangd configuration file

### DIFF
--- a/clangd/.clangd
+++ b/clangd/.clangd
@@ -1,0 +1,35 @@
+CompileFlags:
+  Add:
+    - -Wall
+    - -Wextra
+    - -Wpedantic
+    - -Wdocumentation
+    - -Wdocumentation-pedantic
+    - -Wconversion
+    - -Wsign-compare
+
+Diagnostics:
+  ClangTidy:
+    Add:
+      - bugprone-*
+      - performance-*
+      - cert-*
+      - cppcoreguidelines-*
+      - hicpp-*
+      - modernize-*
+      - readability-*
+      - portability-*
+    Remove:
+      - modernize-use-trailing-return-type
+      - cppcoreguidelines-avoid-magic-numbers
+      - readability-magic-numbers
+    CheckOptions:
+      readability-function-size.StatementThreshold: 50
+      readability-function-size.ParameterThreshold: 5
+      readability-function-size.NestingThreshold: 4
+      hicpp-avoid-c-arrays.AllowStringArrays: true
+      modernize-avoid-c-arrays.AllowStringArrays: true
+      cppcoreguidelines-avoid-c-arrays.AllowStringArrays: true
+      readability-function-cognitive-complexity.Threshold: 10
+  UnusedIncludes: Strict
+  MissingIncludes: Strict


### PR DESCRIPTION
As we use clangd as part of enforcing our coding guidelines, the respective configuration file should be subject to version control.