### PR TITLE
Add srcs filegroup to swift_c_binary and swift_cc_binary

### DIFF
--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -422,6 +422,8 @@ def swift_c_binary(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _create_srcs(**kwargs)
+
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])
@@ -472,6 +474,8 @@ def swift_cc_binary(**kwargs):
             nocopts: List of flags to remove from the default compile
             options. Use judiciously.
     """
+    _create_srcs(**kwargs)
+
     local_includes = _construct_local_includes(kwargs.pop("local_includes", []))
 
     nocopts = kwargs.pop("nocopts", [])


### PR DESCRIPTION
Add srcs filegroup to `swift_c_binary` and `swift_cc_binary` to ease doxygen generation, which includes srcs from binaries.