### PR TITLE
Implement tooling to merge SARIF reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
           bazel run //tools/buildifier:buildifier
           git diff --exit-code
 
+      - name: Run tools tests
+        run: |
+          bazel test //tools/...
+
       - name: Build and generate coverage
         run: |
           cd examples/small_world

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,7 +27,9 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 swift_cc_toolchain_ext = use_extension("@rules_swiftnav//cc:extensions.bzl", "swift_cc_toolchain_extension")
 use_repo(
     swift_cc_toolchain_ext,
+    "aarch64-darwin-llvm",
     "aarch64-darwin-llvm20",
+    "aarch64-linux-llvm",
     "aarch64-linux-llvm20",
     "aarch64-linux-musl",
     "aarch64-sysroot",
@@ -35,7 +37,9 @@ use_repo(
     "darwin_gcc_arm_embedded_toolchain",
     "gcc_arm_gnu_8_3_toolchain",
     "llvm_mingw_toolchain",
+    "x86_64-darwin-llvm",
     "x86_64-darwin-llvm20",
+    "x86_64-linux-llvm",
     "x86_64-linux-llvm20",
     "x86_64-linux-musl",
     "x86_64-sysroot",

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT")
+
+py_binary(
+    name = "extract_lint_results",
+    srcs = ["extract_lint_results.py"],
+    main = "extract_lint_results.py",
+    tags = ["manual"],
+)
+
+py_test(
+    name = "extract_lint_results_test",
+    srcs = [
+        "extract_lint_results.py",
+        "extract_lint_results_test.py",
+    ],
+    main = "extract_lint_results_test.py",
+    tags = [UNIT],
+    target_compatible_with = select({
+        "@platforms//os:linux": ["@platforms//cpu:x86_64"],
+        "@platforms//os:macos": ["@platforms//cpu:aarch64"],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+)

--- a/tools/lint/extract_lint_results.py
+++ b/tools/lint/extract_lint_results.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""
+Extract and merge linting results from a Bazel build.
+
+Collects SARIF (Static Analysis Results Interchange Format) report files and
+patch files from a Bazel Build Event Protocol JSON file, merges the SARIF
+reports into a single file for efficient processing by reviewdog, and copies
+non-empty patch files to a specified directory.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def extract_files_from_bep(
+    build_event_json_file: Path,
+    bazel_output_path: Path,
+    ext: str,
+) -> list[Path]:
+    """
+    Extract file paths with the given extension from a Bazel Build Event Protocol JSON file.
+
+    The BEP file is newline-delimited JSON. Each line is parsed for namedSetOfFiles
+    entries, and files whose name ends with the given extension are collected.
+
+    Args:
+        build_event_json_file: Path to the Bazel build event JSON file
+        ext: File extension to filter
+        bazel_output_path: Workspace root used to resolve relative BEP paths
+            (e.g. paths starting with bazel-out/). When omitted, paths are kept
+            as-is (relative to the current working directory).
+
+    Returns:
+        List of matching file paths
+    """
+    report_files = []
+
+    with open(build_event_json_file, "r") as f:
+        for line in f:
+            line = line.strip().rstrip("\r")
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                print(
+                    f"Error: Build event JSON file contains errors: {build_event_json_file}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            named_set = event.get("namedSetOfFiles")
+            if named_set is None:
+                continue
+
+            for file_info in named_set.get("files", []):
+                name = file_info.get("name", "")
+                if name.endswith(ext):
+                    path_prefix = file_info.get("pathPrefix", [])
+                    path = Path("/".join(path_prefix) + "/" + name)
+                    if not path.is_absolute() and bazel_output_path is not None:
+                        path = bazel_output_path / path
+                    report_files.append(path)
+
+    return report_files
+
+
+def normalize_path(uri: str, workspace_root: Path | None = None) -> str:
+    """
+    Normalize Bazel execroot paths to repository-relative paths.
+
+    Strips Bazel's execroot structure (e.g., '../../../902/execroot/_main/')
+    to make paths relative to the repository root for reviewdog.
+    Also resolves Bazel _virtual_includes symlinks created by strip_include_prefix.
+
+    Args:
+        uri: Original URI from SARIF report
+        workspace_root: Repository root used to resolve _virtual_includes symlinks
+
+    Returns:
+        Normalized path relative to repository root
+    """
+    # Pattern to match Bazel execroot paths like:
+    # ../../../902/execroot/_main/lib1/...
+    # ../../execroot/_main/lib1/...
+    # The pattern captures everything after 'execroot/_main/' or 'execroot/__main__/'
+    execroot_pattern = r"(?:\.\./)*(?:\d+/)?execroot/(?:_main|__main__)/(.*)"
+
+    match = re.match(execroot_pattern, uri)
+    if match:
+        normalized = match.group(1)
+    else:
+        # If no execroot pattern found, return the URI as-is
+        # but strip leading '../' if present
+        normalized = uri.lstrip("../")
+
+    # Resolve _virtual_includes symlinks produced by strip_include_prefix.
+    # Bazel creates a symlink forest under bazel-out/.../bin/<pkg>/_virtual_includes/
+    # pointing back into the real source tree. Follow the symlink so that the
+    # resulting path matches the PR diff (e.g. lib1/include/foo.h instead of
+    # bazel-out/.../lib1/_virtual_includes/foo.h).
+    if "_virtual_includes" in normalized and workspace_root is not None:
+        full_path = workspace_root / normalized
+        try:
+            resolved = Path(os.path.realpath(full_path))
+            canonical_root = Path(os.path.realpath(workspace_root))
+            normalized = str(resolved.relative_to(canonical_root))
+        except (OSError, ValueError):
+            pass  # Keep original if the symlink cannot be resolved
+
+    return normalized
+
+
+def normalize_sarif_paths(
+    run: dict[str, Any], workspace_root: Path | None = None
+) -> dict[str, Any]:
+    """
+    Normalize all file paths in a SARIF run to be repository-relative.
+
+    Args:
+        run: A SARIF run object
+        workspace_root: Repository root used to resolve _virtual_includes symlinks
+
+    Returns:
+        The run object with normalized paths
+    """
+    # Normalize paths in results
+    artifacts = (
+        loc.get("physicalLocation", {}).get("artifactLocation")
+        for res in run.get("results", [])
+        for loc in res.get("locations", [])
+    )
+
+    for artifact in artifacts:
+        if artifact and "uri" in artifact:
+            artifact["uri"] = normalize_path(artifact["uri"], workspace_root)
+            artifact.pop("uriBaseId", None)
+
+    return run
+
+
+def filter_external_dependencies(run: dict[str, Any]) -> dict[str, Any]:
+    """
+    Remove results whose primary location points to a Bazel external dependency.
+
+    Bazel downloads external repositories (Eigen, Abseil, etc.) into a directory
+    that is only reachable through the Bazel execroot symlink.  Inside Docker the
+    bazel-out symlink is broken, so SonarCloud cannot resolve these paths and
+    falls back to project-level issues with no source context.  Dropping them
+    here keeps the report clean and avoids misleading project-level noise.
+
+    After normalize_sarif_paths the affected URIs start with 'external/'.
+
+    Args:
+        run: A SARIF run object
+
+    Returns:
+        The run object with external-dependency results removed
+    """
+    if "results" not in run:
+        return run
+    run["results"] = [
+        result
+        for result in run["results"]
+        if not result.get("locations", [{}])[0]
+        .get("physicalLocation", {})
+        .get("artifactLocation", {})
+        .get("uri", "")
+        .startswith("external/")
+    ]
+    return run
+
+
+def filter_errors_only(run: dict[str, Any]) -> dict[str, Any]:
+    """
+    Filter a SARIF run to only keep results with level "error".
+
+    Args:
+        run: A SARIF run object
+
+    Returns:
+        The run object with only error-level results
+    """
+    if "results" in run:
+        run["results"] = [
+            result for result in run["results"] if result.get("level") == "error"
+        ]
+    return run
+
+
+_CHECK_RE = re.compile(r"\[([a-zA-Z0-9_\-\.]+)\]$")
+
+
+def extract_rule_ids(run: dict[str, Any]) -> dict[str, Any]:
+    """
+    Backfill ruleId on SARIF results that are missing it.
+
+    clang-tidy embeds the check name at the end of each message as [check-name]
+    but does not populate the SARIF ruleId field.  SonarQube silently drops any
+    result that lacks a ruleId, so this function extracts the check name from
+    the message text and sets it as ruleId.
+
+    Also populates the tool.driver.rules array so SonarQube can resolve rule
+    metadata even when the original SARIF driver section lists no rules.
+
+    Args:
+        run: A SARIF run object (mutated in-place)
+
+    Returns:
+        The same run object with ruleId fields filled in
+    """
+    known_rules: dict[str, dict[str, Any]] = {
+        r["id"]: r for r in run.get("tool", {}).get("driver", {}).get("rules", [])
+    }
+
+    for result in run.get("results", []):
+        if "ruleId" in result:
+            continue
+        msg = result.get("message", {}).get("text", "").strip()
+        m = _CHECK_RE.search(msg)
+        if m:
+            rule_id = m.group(1)
+            result["ruleId"] = rule_id
+            if rule_id not in known_rules:
+                # Carry the SARIF level into defaultConfiguration so SonarQube
+                # can use it as the rule severity instead of defaulting to MEDIUM.
+                level = result.get("level", "warning")
+                known_rules[rule_id] = {
+                    "id": rule_id,
+                    "defaultConfiguration": {"level": level},
+                }
+
+    run.setdefault("tool", {}).setdefault("driver", {})["rules"] = list(
+        known_rules.values()
+    )
+    return run
+
+
+def deduplicate_runs(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """
+    Deduplicate results across a list of SARIF runs.
+
+    Header files are included by multiple .cc compilation units, producing one
+    clang-tidy run per including file and therefore one copy of each header
+    diagnostic per includer. This function collapses those duplicates, keying
+    on (uri, startLine, startColumn, ruleId).
+
+    Args:
+        runs: List of SARIF run objects (may contain duplicate results)
+
+    Returns:
+        The same list of runs with duplicate results removed. Duplicates are
+        dropped from later runs; the first occurrence is kept.
+    """
+    seen: set[tuple[str, int, int, str]] = set()
+    for run in runs:
+        unique = []
+        for result in run.get("results", []):
+            phys = result.get("locations", [{}])[0].get("physicalLocation", {})
+            uri = phys.get("artifactLocation", {}).get("uri", "")
+            region = phys.get("region", {})
+            key = (
+                uri,
+                region.get("startLine", 0),
+                region.get("startColumn", 0),
+                result.get("ruleId", ""),
+            )
+            if key not in seen:
+                seen.add(key)
+                unique.append(result)
+        if "results" in run:
+            run["results"] = unique
+    return runs
+
+
+def collect_and_merge_sarif(
+    build_event_json_file: Path,
+    output_merged_sarif_file: Path,
+    bazel_output_path: Path,
+    only_errors: bool = False,
+) -> int:
+    """
+    Find all .report files from the BEP file and merge them into a single SARIF file.
+
+    Args:
+        build_event_json_file: Path to the Bazel build event JSON file
+        output_merged_sarif_file: Output path for the merged SARIF report
+        bazel_output_path: Workspace root used to resolve relative BEP paths
+        only_errors: If True, filter results to only include error-level findings
+
+    Returns:
+        Total number of results in the merged report
+    """
+    report_files = extract_files_from_bep(
+        build_event_json_file=build_event_json_file,
+        bazel_output_path=bazel_output_path,
+        ext=".report",
+    )
+    print(f"Found {len(report_files)} .report files from build events")
+    for report in report_files:
+        print(f"  - {report}")
+
+    return merge_sarif_reports(
+        input_files=report_files,
+        output_file=output_merged_sarif_file,
+        only_errors=only_errors,
+        workspace_root=bazel_output_path,
+    )
+
+
+def collect_patches(
+    build_event_json_file: Path,
+    output_patch_folder: Path,
+    bazel_output_path: Path,
+) -> None:
+    """
+    Copy non-empty patch files listed in the BEP file to the given folder.
+
+    Args:
+        build_event_json_file: Path to the Bazel build event JSON file
+        output_patch_folder: Directory to copy patch files into
+        bazel_output_path: Workspace root used to resolve relative BEP paths
+    """
+    patch_files = extract_files_from_bep(
+        build_event_json_file,
+        bazel_output_path=bazel_output_path,
+        ext=".patch",
+    )
+    output_patch_folder.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for patch in patch_files:
+        if patch.exists() and patch.stat().st_size > 0:
+            dest = output_patch_folder / patch.name
+            dest.unlink(missing_ok=True)
+            shutil.copy2(patch, dest)
+            copied += 1
+    if copied > 0:
+        print(f"Copied {copied} patch file(s) to {output_patch_folder}")
+
+
+def merge_sarif_reports(
+    input_files: list[Path],
+    output_file: Path,
+    only_errors: bool = False,
+    workspace_root: Path | None = None,
+) -> int:
+    """
+    Merge multiple SARIF report files into a single SARIF file.
+    Normalizes Bazel execroot paths to repository-relative paths.
+
+    Args:
+        input_files: List of paths to input SARIF files
+        output_file: Path to write the merged SARIF file
+        only_errors: If True, filter results to only include error-level findings
+        workspace_root: Repository root used to resolve _virtual_includes symlinks
+    """
+    if not input_files:
+        print("No input files to merge", file=sys.stderr)
+        # Create an empty but valid SARIF file
+        merged_sarif: dict[str, Any] = {"version": "2.1.0", "runs": []}
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, "w") as f:
+            json.dump(merged_sarif, f, indent=2)
+        print(f"Created empty SARIF report at {output_file}")
+        return 0
+
+    merged_runs = []
+    schema_version = "2.1.0"
+    schema_uri = None
+    processed_files = 0
+    normalized_paths = 0
+
+    for input_file in input_files:
+        if not input_file.exists() or input_file.stat().st_size == 0:
+            print(f"Skipping empty or non-existent file: {input_file}", file=sys.stderr)
+            continue
+
+        try:
+            with open(input_file, "r") as f:
+                data = json.load(f)
+
+            # Extract schema information from first valid file
+            if schema_uri is None and "$schema" in data:
+                schema_uri = data["$schema"]
+
+            if "version" in data:
+                schema_version = data["version"]
+
+            # Collect all runs from this file and normalize paths
+            if "runs" in data:
+                for run in data["runs"]:
+                    normalized_run = normalize_sarif_paths(run, workspace_root)
+                    normalized_run = filter_external_dependencies(normalized_run)
+                    normalized_run = extract_rule_ids(normalized_run)
+                    if only_errors:
+                        normalized_run = filter_errors_only(normalized_run)
+                    results = normalized_run.get("results", [])
+                    if not results:
+                        continue
+                    merged_runs.append(normalized_run)
+                    normalized_paths += len(results)
+                processed_files += 1
+
+        except Exception as e:
+            print(
+                f"Error processing {input_file}: {e}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    # Create the merged SARIF structure; filter out any runs left empty by deduplication
+    merged_sarif = {
+        "version": schema_version,
+        "runs": [r for r in deduplicate_runs(merged_runs) if r.get("results")],
+    }
+
+    if schema_uri:
+        merged_sarif["$schema"] = schema_uri
+
+    # Ensure output directory exists
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write the merged file
+    with open(output_file, "w") as f:
+        json.dump(merged_sarif, f, indent=2)
+
+    print(
+        f"Successfully merged {len(merged_runs)} runs from {processed_files} files into {output_file}"
+    )
+    print(f"Normalized paths for {normalized_paths} results")
+    return normalized_paths
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect and merge SARIF report files from a Bazel Build Event Protocol JSON file into a single file."
+    )
+    parser.add_argument(
+        "--build-event-json-file",
+        type=Path,
+        required=True,
+        help="Path to the Bazel build event JSON file (passed via --build-event-json-file to bazel build)",
+    )
+    parser.add_argument(
+        "--bazel-output-path",
+        type=Path,
+        required=True,
+        help="Workspace root used to resolve relative paths from the build event JSON file (e.g. $(pwd) when invoking from the repo root)",
+    )
+    parser.add_argument(
+        "--output-merged-sarif-file",
+        type=Path,
+        default=None,
+        help="Output file path for the merged SARIF report (e.g., sarif-reports/merged-report.sarif)",
+    )
+    parser.add_argument(
+        "--exit-code",
+        type=int,
+        default=None,
+        help="Exit with this code if any errors are found in the merged report",
+    )
+    parser.add_argument(
+        "--only-errors",
+        action="store_true",
+        default=False,
+        help="Keep only error-level results in the merged report, removing warnings and other findings",
+    )
+    parser.add_argument(
+        "--output-patch-folder",
+        type=Path,
+        default=None,
+        help="Directory to collect non-empty patch files from the build event JSON file",
+    )
+
+    args = parser.parse_args()
+
+    if not args.build_event_json_file.exists():
+        print(
+            f"Error: Build event JSON file does not exist: {args.build_event_json_file}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    total_results = 0
+    if args.output_merged_sarif_file is not None:
+        total_results = collect_and_merge_sarif(
+            build_event_json_file=args.build_event_json_file,
+            output_merged_sarif_file=args.output_merged_sarif_file,
+            bazel_output_path=args.bazel_output_path,
+            only_errors=args.only_errors,
+        )
+
+    if args.output_patch_folder is not None:
+        collect_patches(
+            build_event_json_file=args.build_event_json_file,
+            output_patch_folder=args.output_patch_folder,
+            bazel_output_path=args.bazel_output_path,
+        )
+
+    if args.exit_code is not None and total_results > 0:
+        sys.exit(args.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/lint/extract_lint_results_test.py
+++ b/tools/lint/extract_lint_results_test.py
@@ -1,0 +1,1092 @@
+#!/usr/bin/env python3
+"""Tests for extract_lint_results.py
+
+Run with Bazel:
+    bazel test //tools/...
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.lint.extract_lint_results import (
+    collect_and_merge_sarif,
+    collect_patches,
+    deduplicate_runs,
+    extract_files_from_bep,
+    extract_rule_ids,
+    filter_errors_only,
+    filter_external_dependencies,
+    main,
+    merge_sarif_reports,
+    normalize_path,
+    normalize_sarif_paths,
+)
+
+
+def _write_sarif(path: Path, results: list, tool_name: str = "ClangTidy") -> None:
+    """Write a minimal SARIF file with the given results."""
+    data = {
+        "version": "2.1.0",
+        "runs": [{"tool": {"driver": {"name": tool_name}}, "results": results}],
+    }
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+def _file(name: str, path_prefix: list) -> dict:
+    """Build a single BEP file entry."""
+    return {"name": name, "pathPrefix": path_prefix}
+
+
+def _named_set_event(*files: dict) -> str:
+    """Return a BEP namedSetOfFiles JSON line for the given file entries."""
+    return json.dumps({"namedSetOfFiles": {"files": list(files)}}) + "\n"
+
+
+def _write_bep(bep_path: Path, file_paths: list) -> None:
+    """Write a BEP JSON file with namedSetOfFiles entries for the given paths."""
+    with open(bep_path, "w") as f:
+        for file_path in file_paths:
+            parts = str(file_path).split("/")
+            f.write(_named_set_event(_file(name=parts[-1], path_prefix=parts[:-1])))
+
+
+class TestExtractFilesFromBep(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.p = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_no_named_set_entries_returns_empty(self):
+        """BEP file with no namedSetOfFiles events yields no files."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write(json.dumps({"started": {"uuid": "abc"}}) + "\n")
+
+        self.assertEqual(
+            extract_files_from_bep(bep, bazel_output_path=None, ext=".report"), []
+        )
+
+    def test_returns_files_matching_extension(self):
+        """Only files whose name ends with the requested extension are returned."""
+        bep = self.p / "bep.json"
+        bep.write_text(
+            _named_set_event(
+                _file(name="foo.report", path_prefix=["/tmp"]),
+                _file(name="foo.report.exit_code", path_prefix=["/tmp"]),
+                _file(name="other.txt", path_prefix=["/tmp"]),
+            )
+        )
+
+        result = extract_files_from_bep(bep, bazel_output_path=None, ext=".report")
+        self.assertEqual(result, [Path("/tmp/foo.report")])
+
+    def test_collects_from_multiple_events(self):
+        """Files from every namedSetOfFiles event in the BEP file are collected."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write(_named_set_event(_file(name="a.report", path_prefix=["/tmp"])))
+            f.write(json.dumps({"started": {"uuid": "skip"}}) + "\n")
+            f.write(_named_set_event(_file(name="b.report", path_prefix=["/tmp"])))
+
+        result = extract_files_from_bep(bep, bazel_output_path=None, ext=".report")
+        self.assertEqual(len(result), 2)
+
+    def test_relative_path_resolved_with_bazel_output_path(self):
+        """A relative path from the BEP is joined with bazel_output_path."""
+        bep = self.p / "bep.json"
+        bep.write_text(_named_set_event(_file(name="foo.report", path_prefix=["bazel-out", "k8-fastbuild", "bin"])))
+
+        result = extract_files_from_bep(
+            bep, bazel_output_path=Path("/workspace"), ext=".report"
+        )
+        self.assertEqual(
+            result, [Path("/workspace/bazel-out/k8-fastbuild/bin/foo.report")]
+        )
+
+    def test_absolute_path_not_modified_by_bazel_output_path(self):
+        """An absolute path in the BEP is used as-is regardless of bazel_output_path."""
+        bep = self.p / "bep.json"
+        bep.write_text(_named_set_event(_file(name="foo.report", path_prefix=["/absolute", "path"])))
+
+        result = extract_files_from_bep(
+            bep, bazel_output_path=Path("/workspace"), ext=".report"
+        )
+        self.assertEqual(result, [Path("/absolute/path/foo.report")])
+
+    def test_invalid_json_line_exits_with_code_1(self):
+        """Invalid JSON lines in the BEP file cause exit with code 1."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write("not valid json\n")
+            f.write(_named_set_event(_file(name="foo.report", path_prefix=["/tmp"])))
+
+        with self.assertRaises(SystemExit) as ctx:
+            extract_files_from_bep(bep, bazel_output_path=None, ext=".report")
+        self.assertEqual(ctx.exception.code, 1)
+
+
+class TestNormalizePath(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_execroot_main_with_numeric_hash(self):
+        """Bazel path with numeric hash segment before execroot is stripped."""
+        self.assertEqual(
+            normalize_path("../../../902/execroot/_main/lib/file.h"),
+            "lib/file.h",
+        )
+
+    def test_execroot_double_underscore_main(self):
+        """Bazel path with __main__ workspace name is stripped."""
+        self.assertEqual(
+            normalize_path("../../execroot/__main__/integration/main.cc"),
+            "integration/main.cc",
+        )
+
+    def test_non_execroot_path_strips_leading_dotdot(self):
+        """Paths without execroot have leading ../ segments removed."""
+        self.assertEqual(
+            normalize_path("../../../some/other/path.cc"),
+            "some/other/path.cc",
+        )
+
+    def test_already_relative_path_unchanged(self):
+        """A path with no leading ../ and no execroot is returned unchanged."""
+        self.assertEqual(
+            normalize_path("lib/src/file.cc"),
+            "lib/src/file.cc",
+        )
+
+    def test_virtual_includes_symlink_resolved_to_real_source_path(self):
+        """_virtual_includes path is resolved via symlink to the real source file.
+
+        This mirrors the strip_include_prefix case: Bazel creates a symlink forest
+        under _virtual_includes/ pointing into the real include/ directory.
+        Clang-tidy reports the symlink path; we must map it back to the actual
+        source path so reviewdog can match the PR diff.
+        """
+        # Real source file: <workspace>/mylib/include/mylib/header.h
+        real_include_dir = self.workspace / "mylib" / "include"
+        real_include_dir.mkdir(parents=True)
+        real_file = real_include_dir / "mylib" / "header.h"
+        real_file.parent.mkdir(parents=True)
+        real_file.touch()
+
+        # Bazel symlink: bazel-out/.../bin/mylib/_virtual_includes/mylib/
+        #                -> <workspace>/mylib/include/
+        virtual_includes_dir = (
+            self.workspace
+            / "bazel-out"
+            / "k8-fastbuild"
+            / "bin"
+            / "mylib"
+            / "_virtual_includes"
+            / "mylib"
+        )
+        virtual_includes_dir.parent.mkdir(parents=True)
+        virtual_includes_dir.symlink_to(real_include_dir)
+
+        uri = "bazel-out/k8-fastbuild/bin/mylib/_virtual_includes/mylib/mylib/header.h"
+        result = normalize_path(uri, workspace_root=self.workspace)
+
+        self.assertEqual(result, "mylib/include/mylib/header.h")
+
+    def test_virtual_includes_without_workspace_root_returned_as_is(self):
+        """Without workspace_root, _virtual_includes paths are not resolved."""
+        uri = "bazel-out/k8-fastbuild/bin/pkg/_virtual_includes/pkg/pkg/file.h"
+        self.assertEqual(normalize_path(uri, workspace_root=None), uri)
+
+    def test_virtual_includes_broken_symlink_falls_back_to_original(self):
+        """If the _virtual_includes symlink does not exist, the path is kept unchanged."""
+        uri = "bazel-out/k8-fastbuild/bin/pkg/_virtual_includes/pkg/pkg/file.h"
+        # workspace_root is provided but the symlink does not exist on disk
+        result = normalize_path(uri, workspace_root=self.workspace)
+        self.assertEqual(result, uri)
+
+    def test_execroot_path_with_virtual_includes_is_fully_resolved(self):
+        """execroot prefix is stripped first, then _virtual_includes symlink is resolved."""
+        real_include_dir = self.workspace / "pkg" / "include"
+        real_include_dir.mkdir(parents=True)
+        (real_include_dir / "pkg").mkdir()
+        (real_include_dir / "pkg" / "file.h").touch()
+
+        virtual_dir = (
+            self.workspace
+            / "bazel-out"
+            / "k8-fastbuild"
+            / "bin"
+            / "pkg"
+            / "_virtual_includes"
+            / "pkg"
+        )
+        virtual_dir.parent.mkdir(parents=True)
+        virtual_dir.symlink_to(real_include_dir)
+
+        uri = "../../execroot/_main/bazel-out/k8-fastbuild/bin/pkg/_virtual_includes/pkg/pkg/file.h"
+        result = normalize_path(uri, workspace_root=self.workspace)
+        self.assertEqual(result, "pkg/include/pkg/file.h")
+
+
+class TestNormalizeSarifPaths(unittest.TestCase):
+    def test_normalizes_uri_and_removes_uri_base_id(self):
+        """execroot URI is normalized and uriBaseId is removed."""
+        run = {
+            "results": [
+                {
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "../../../902/execroot/_main/lib/file.h",
+                                    "uriBaseId": "%SRCROOT%",
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+        artifact = normalize_sarif_paths(run)["results"][0]["locations"][0][
+            "physicalLocation"
+        ]["artifactLocation"]
+        self.assertEqual(artifact["uri"], "lib/file.h")
+        self.assertNotIn("uriBaseId", artifact)
+
+    def test_all_results_are_normalized(self):
+        """Every result in the run has its path normalized."""
+        run = {
+            "results": [
+                {
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "../../execroot/_main/a.cc"}
+                            }
+                        }
+                    ]
+                },
+                {
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "../../execroot/_main/b.cc"}
+                            }
+                        }
+                    ]
+                },
+            ]
+        }
+        normalized = normalize_sarif_paths(run)
+        self.assertEqual(
+            normalized["results"][0]["locations"][0]["physicalLocation"][
+                "artifactLocation"
+            ]["uri"],
+            "a.cc",
+        )
+        self.assertEqual(
+            normalized["results"][1]["locations"][0]["physicalLocation"][
+                "artifactLocation"
+            ]["uri"],
+            "b.cc",
+        )
+
+    def test_run_without_results_key_is_unchanged(self):
+        """A run dict without a 'results' key is returned without error."""
+        run = {"tool": {"driver": {"name": "ClangTidy"}}}
+        result = normalize_sarif_paths(run)
+        self.assertNotIn("results", result)
+
+    def test_result_without_physical_location_is_unchanged(self):
+        """A result with no physicalLocation is left intact."""
+        run = {"results": [{"message": {"text": "no location"}}]}
+        result = normalize_sarif_paths(run)
+        self.assertEqual(result["results"][0]["message"]["text"], "no location")
+
+
+class TestFilterExternalDependencies(unittest.TestCase):
+    def _result(self, uri: str) -> dict:
+        return {"locations": [{"physicalLocation": {"artifactLocation": {"uri": uri}}}]}
+
+    def test_external_results_removed(self):
+        """Results whose primary URI starts with 'external/' are dropped."""
+        run = {"results": [
+            self._result("external/dep+/include/dep/file.h"),
+            self._result("lib/src/file.cc"),
+        ]}
+        result = filter_external_dependencies(run)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(
+            result["results"][0]["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            "lib/src/file.cc",
+        )
+
+    def test_all_external_results_emptied(self):
+        """A run whose only results are external dependencies is emptied."""
+        run = {"results": [
+            self._result("external/dep2+/include/dep2/file.hpp"),
+        ]}
+        result = filter_external_dependencies(run)
+        self.assertEqual(result["results"], [])
+
+    def test_run_without_results_key_unchanged(self):
+        """A run dict without a 'results' key is returned without error."""
+        run = {"tool": {"driver": {"name": "ClangTidy"}}}
+        result = filter_external_dependencies(run)
+        self.assertNotIn("results", result)
+
+    def test_result_without_location_kept(self):
+        """A result with no locations (no URI to check) is kept."""
+        run = {"results": [{"message": {"text": "no location"}}]}
+        result = filter_external_dependencies(run)
+        self.assertEqual(len(result["results"]), 1)
+
+
+class TestExtractRuleIds(unittest.TestCase):
+    def _run(self, results):
+        return {"tool": {"driver": {"name": "ClangTidy", "rules": []}}, "results": results}
+
+    def test_rule_id_extracted_from_message_bracket_suffix(self):
+        """ruleId is parsed from the trailing [check-name] in the message text."""
+        run = self._run([{"level": "warning", "message": {"text": "some issue [misc-include-cleaner]"}}])
+        result = extract_rule_ids(run)
+        self.assertEqual(result["results"][0]["ruleId"], "misc-include-cleaner")
+
+    def test_existing_rule_id_not_overwritten(self):
+        """Results that already have ruleId are left unchanged."""
+        run = self._run([{"ruleId": "existing-rule", "message": {"text": "msg [other-rule]"}}])
+        result = extract_rule_ids(run)
+        self.assertEqual(result["results"][0]["ruleId"], "existing-rule")
+
+    def test_message_without_bracket_suffix_skipped(self):
+        """Results whose message has no [check-name] suffix get no ruleId added."""
+        run = self._run([{"level": "warning", "message": {"text": "no check name here"}}])
+        result = extract_rule_ids(run)
+        self.assertNotIn("ruleId", result["results"][0])
+
+    def test_rules_array_populated_in_driver(self):
+        """Extracted check names are added to tool.driver.rules with defaultConfiguration.level."""
+        run = self._run([
+            {"level": "warning", "message": {"text": "issue [modernize-use-nullptr]"}},
+            {"level": "error", "message": {"text": "issue [misc-include-cleaner]"}},
+        ])
+        result = extract_rule_ids(run)
+        rules_by_id = {r["id"]: r for r in result["tool"]["driver"]["rules"]}
+        self.assertIn("modernize-use-nullptr", rules_by_id)
+        self.assertIn("misc-include-cleaner", rules_by_id)
+        self.assertEqual(rules_by_id["modernize-use-nullptr"]["defaultConfiguration"]["level"], "warning")
+        self.assertEqual(rules_by_id["misc-include-cleaner"]["defaultConfiguration"]["level"], "error")
+
+    def test_duplicate_check_names_appear_once_in_rules(self):
+        """The same check name appearing in multiple results is deduplicated in rules."""
+        run = self._run([
+            {"message": {"text": "a [misc-include-cleaner]"}},
+            {"message": {"text": "b [misc-include-cleaner]"}},
+        ])
+        result = extract_rule_ids(run)
+        ids = [r["id"] for r in result["tool"]["driver"]["rules"]]
+        self.assertEqual(ids.count("misc-include-cleaner"), 1)
+
+    def test_merge_sarif_reports_populates_rule_ids(self):
+        """End-to-end: merge_sarif_reports fills in ruleId from message text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inp = Path(tmp) / "a.sarif"
+            data = {
+                "version": "2.1.0",
+                "runs": [{"tool": {"driver": {"name": "ClangTidy"}}, "results": [
+                    {"level": "warning",
+                     "message": {"text": "nested namespaces can be concatenated [modernize-concat-nested-namespaces]"},
+                     "locations": [{"physicalLocation": {"artifactLocation": {"uri": "src/file.cc"},
+                                                         "region": {"startLine": 5, "startColumn": 1}}}]},
+                ]}],
+            }
+            with open(inp, "w") as f:
+                json.dump(data, f)
+            out = Path(tmp) / "out.sarif"
+            merge_sarif_reports([inp], out)
+            result = json.loads(out.read_text())
+            self.assertEqual(result["runs"][0]["results"][0]["ruleId"], "modernize-concat-nested-namespaces")
+
+
+class TestFilterErrorsOnly(unittest.TestCase):
+    def test_keeps_only_error_level_results(self):
+        """warning, note, and none results are removed; error results are kept."""
+        run = {
+            "results": [
+                {"level": "error", "message": {"text": "err"}},
+                {"level": "warning", "message": {"text": "warn"}},
+                {"level": "note", "message": {"text": "note"}},
+                {"level": "none", "message": {"text": "none"}},
+            ]
+        }
+        filtered = filter_errors_only(run)
+        self.assertEqual(len(filtered["results"]), 1)
+        self.assertEqual(filtered["results"][0]["level"], "error")
+
+    def test_results_missing_level_field_are_removed(self):
+        """Results without a 'level' key are excluded."""
+        run = {
+            "results": [
+                {"message": {"text": "no level"}},
+                {"level": "error", "message": {"text": "err"}},
+            ]
+        }
+        filtered = filter_errors_only(run)
+        self.assertEqual(len(filtered["results"]), 1)
+
+    def test_run_without_results_key_is_returned_as_is(self):
+        run = {"tool": {"driver": {"name": "tool"}}}
+        result = filter_errors_only(run)
+        self.assertNotIn("results", result)
+
+
+class TestDeduplicateRuns(unittest.TestCase):
+    def _result(self, uri, line, col, rule_id):
+        return {
+            "ruleId": rule_id,
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": uri},
+                        "region": {"startLine": line, "startColumn": col},
+                    }
+                }
+            ],
+        }
+
+    def test_no_duplicates_unchanged(self):
+        """Runs with no duplicate results are returned as-is."""
+        runs = [
+            {
+                "results": [
+                    self._result("a.h", 10, 1, "rule1"),
+                    self._result("b.h", 20, 1, "rule2"),
+                ]
+            }
+        ]
+        result = deduplicate_runs(runs)
+        self.assertEqual(len(result[0]["results"]), 2)
+
+    def test_same_result_across_runs_deduplicated(self):
+        """The same (uri, line, col, ruleId) in two runs keeps only the first occurrence."""
+        dup = self._result("include/foo.h", 45, 3, "google-explicit-constructor")
+        runs = [{"results": [dup]}, {"results": [dup]}]
+        result = deduplicate_runs(runs)
+        total = sum(len(r["results"]) for r in result)
+        self.assertEqual(total, 1)
+
+    def test_different_rules_same_location_both_kept(self):
+        """Two different rules at the same location are both kept."""
+        runs = [
+            {
+                "results": [
+                    self._result("foo.h", 10, 1, "rule-a"),
+                    self._result("foo.h", 10, 1, "rule-b"),
+                ]
+            }
+        ]
+        result = deduplicate_runs(runs)
+        self.assertEqual(len(result[0]["results"]), 2)
+
+    def test_same_rule_different_lines_both_kept(self):
+        """Same rule on different lines are both kept."""
+        runs = [
+            {
+                "results": [
+                    self._result("foo.h", 10, 1, "rule-a"),
+                    self._result("foo.h", 20, 1, "rule-a"),
+                ]
+            }
+        ]
+        result = deduplicate_runs(runs)
+        self.assertEqual(len(result[0]["results"]), 2)
+
+    def test_run_without_results_key_unchanged(self):
+        """A run with no 'results' key is left intact."""
+        runs = [{"tool": {"driver": {"name": "ClangTidy"}}}]
+        result = deduplicate_runs(runs)
+        self.assertNotIn("results", result[0])
+
+    def test_multiple_duplicate_runs_mirrors_real_header_scenario(self):
+        """Mirrors the real scenario: same header warning in N .cc compilation units."""
+        header_warn = self._result(
+            "mylib/include/mylib/header1.h",
+            45,
+            3,
+            "google-explicit-constructor",
+        )
+        other = self._result(
+            "mylib/include/mylib/header2.h",
+            129,
+            1,
+            "readability-convert-member-functions-to-static",
+        )
+        runs = [
+            {"results": [header_warn, other]},
+            {"results": [header_warn]},
+            {"results": [header_warn]},
+        ]
+        result = deduplicate_runs(runs)
+        total = sum(len(r["results"]) for r in result)
+        self.assertEqual(total, 2)
+
+
+class TestMergeSarifReports(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.p = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_empty_input_creates_valid_empty_sarif(self):
+        """No input files --> output is a valid SARIF 2.1.0 file with empty runs."""
+        out = self.p / "out.sarif"
+        count = merge_sarif_reports([], out)
+        self.assertEqual(count, 0)
+        self.assertTrue(out.exists())
+        data = json.loads(out.read_text())
+        self.assertEqual(data["version"], "2.1.0")
+        self.assertEqual(data["runs"], [])
+
+    def test_single_file_runs_are_included(self):
+        """Runs from a single input file appear in the output."""
+        inp = self.p / "a.sarif"
+        _write_sarif(inp, [{"message": {"text": "issue"}}], tool_name="ToolA")
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp], out)
+        data = json.loads(out.read_text())
+        self.assertEqual(len(data["runs"]), 1)
+        self.assertEqual(data["runs"][0]["tool"]["driver"]["name"], "ToolA")
+
+    def test_multiple_files_runs_are_combined(self):
+        """Runs from all input files are combined into the output."""
+        inp1, inp2 = self.p / "a.sarif", self.p / "b.sarif"
+        _write_sarif(
+            inp1,
+            [
+                {
+                    "message": {"text": "e1"},
+                    "ruleId": "check-1",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "a.cc"},
+                                "region": {"startLine": 1, "startColumn": 1},
+                            }
+                        }
+                    ],
+                }
+            ],
+            tool_name="Tool1",
+        )
+        _write_sarif(
+            inp2,
+            [
+                {
+                    "message": {"text": "e2"},
+                    "ruleId": "check-2",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "b.cc"},
+                                "region": {"startLine": 2, "startColumn": 1},
+                            }
+                        }
+                    ],
+                }
+            ],
+            tool_name="Tool2",
+        )
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp1, inp2], out)
+        data = json.loads(out.read_text())
+        names = {r["tool"]["driver"]["name"] for r in data["runs"]}
+        self.assertEqual(names, {"Tool1", "Tool2"})
+
+    def test_returns_total_result_count(self):
+        """Return value equals total number of results across all input files."""
+        inp1, inp2 = self.p / "a.sarif", self.p / "b.sarif"
+        _write_sarif(inp1, [{"message": {"text": "e1"}}, {"message": {"text": "e2"}}])
+        _write_sarif(inp2, [{"message": {"text": "e3"}}])
+        out = self.p / "out.sarif"
+        self.assertEqual(merge_sarif_reports([inp1, inp2], out), 3)
+
+    def test_empty_files_are_skipped(self):
+        """Zero-byte files are silently skipped."""
+        valid = self.p / "valid.sarif"
+        empty = self.p / "empty.sarif"
+        _write_sarif(valid, [{"message": {"text": "issue"}}], tool_name="T")
+        empty.touch()
+        out = self.p / "out.sarif"
+        merge_sarif_reports([valid, empty], out)
+        data = json.loads(out.read_text())
+        self.assertEqual(len(data["runs"]), 1)
+
+    def test_nonexistent_files_are_skipped(self):
+        """Non-existent paths in the input list are silently skipped."""
+        out = self.p / "out.sarif"
+        merge_sarif_reports([self.p / "ghost.sarif"], out)
+        data = json.loads(out.read_text())
+        self.assertEqual(data["runs"], [])
+
+    def test_invalid_json_file_exits_with_code_1(self):
+        """Files containing invalid JSON cause exit with code 1."""
+        bad = self.p / "bad.sarif"
+        bad.write_text("not json")
+        good = self.p / "good.sarif"
+        _write_sarif(good, [{"message": {"text": "issue"}}], tool_name="Good")
+        out = self.p / "out.sarif"
+        with self.assertRaises(SystemExit) as ctx:
+            merge_sarif_reports([bad, good], out)
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_schema_uri_preserved_from_first_valid_file(self):
+        """The $schema field from the first valid input file appears in the output."""
+        inp = self.p / "a.sarif"
+        data = {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [],
+        }
+        with open(inp, "w") as f:
+            json.dump(data, f)
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp], out)
+        result = json.loads(out.read_text())
+        self.assertEqual(
+            result["$schema"], "https://json.schemastore.org/sarif-2.1.0.json"
+        )
+
+    def test_only_errors_filters_non_error_results(self):
+        """With only_errors=True, warnings and notes are removed from the output."""
+        inp = self.p / "a.sarif"
+        _write_sarif(
+            inp,
+            [
+                {"level": "error", "message": {"text": "err"}},
+                {"level": "warning", "message": {"text": "warn"}},
+            ],
+        )
+        out = self.p / "out.sarif"
+        count = merge_sarif_reports([inp], out, only_errors=True)
+        data = json.loads(out.read_text())
+        self.assertEqual(count, 1)
+        self.assertEqual(len(data["runs"][0]["results"]), 1)
+        self.assertEqual(data["runs"][0]["results"][0]["level"], "error")
+
+    def test_bazel_execroot_paths_are_normalized(self):
+        """Bazel execroot URIs in results are rewritten to repo-relative paths."""
+        inp = self.p / "a.sarif"
+        data = {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "T"}},
+                    "results": [
+                        {
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {
+                                            "uri": "../../../902/execroot/_main/lib/file.cc",
+                                            "uriBaseId": "%SRCROOT%",
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ],
+        }
+        with open(inp, "w") as f:
+            json.dump(data, f)
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp], out)
+        result = json.loads(out.read_text())
+        artifact = result["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+            "artifactLocation"
+        ]
+        self.assertEqual(artifact["uri"], "lib/file.cc")
+        self.assertNotIn("uriBaseId", artifact)
+
+    def test_output_directory_is_created_if_missing(self):
+        """The output file's parent directory is created automatically."""
+        inp = self.p / "a.sarif"
+        _write_sarif(inp, [])
+        out = self.p / "subdir" / "nested" / "out.sarif"
+        merge_sarif_reports([inp], out)
+        self.assertTrue(out.exists())
+
+    def test_workspace_root_resolves_virtual_includes_in_sarif(self):
+        """merge_sarif_reports resolves _virtual_includes symlinks when workspace_root is given.
+
+        Reproduces the strip_include_prefix case: Bazel creates _virtual_includes/
+        symlinks. The merged SARIF must contain the real source path so reviewdog
+        can match it against the PR diff.
+        """
+        # Real source file
+        real_include_dir = self.p / "mylib" / "include"
+        (real_include_dir / "mylib").mkdir(parents=True)
+        (real_include_dir / "mylib" / "header.h").touch()
+
+        # Bazel virtual-includes symlink
+        virtual_dir = (
+            self.p
+            / "bazel-out"
+            / "k8-fastbuild"
+            / "bin"
+            / "mylib"
+            / "_virtual_includes"
+            / "mylib"
+        )
+        virtual_dir.parent.mkdir(parents=True)
+        virtual_dir.symlink_to(real_include_dir)
+
+        virtual_uri = "bazel-out/k8-fastbuild/bin/mylib/_virtual_includes/mylib/mylib/header.h"
+        inp = self.p / "a.sarif"
+        data = {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "ClangTidy"}},
+                    "results": [
+                        {
+                            "level": "warning",
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {"uri": virtual_uri}
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        with open(inp, "w") as f:
+            json.dump(data, f)
+
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp], out, workspace_root=self.p)
+
+        result = json.loads(out.read_text())
+        uri = result["runs"][0]["results"][0]["locations"][0]["physicalLocation"][
+            "artifactLocation"
+        ]["uri"]
+        self.assertEqual(uri, "mylib/include/mylib/header.h")
+
+    def test_runs_without_results_are_excluded(self):
+        """Runs that have no results (e.g. clang-tidy found nothing) are dropped from the merged output."""
+        inp = self.p / "mixed.sarif"
+        data = {
+            "version": "2.1.0",
+            "runs": [
+                {"tool": {"driver": {"name": "ClangTidy"}}},
+                {"tool": {"driver": {"name": "ClangTidy"}}, "results": []},
+                {
+                    "tool": {"driver": {"name": "ClangTidy"}},
+                    "results": [
+                        {
+                            "level": "warning",
+                            "message": {"text": "issue"},
+                            "locations": [
+                                {
+                                    "physicalLocation": {
+                                        "artifactLocation": {"uri": "foo.cc"}
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+        with open(inp, "w") as f:
+            json.dump(data, f)
+        out = self.p / "out.sarif"
+        count = merge_sarif_reports([inp], out)
+        result = json.loads(out.read_text())
+        self.assertEqual(count, 1)
+        self.assertEqual(len(result["runs"]), 1)
+        self.assertEqual(len(result["runs"][0]["results"]), 1)
+
+    def test_runs_emptied_by_deduplication_are_excluded(self):
+        """Runs whose results are all duplicates of earlier runs are dropped from the merged output."""
+        result = {
+            "level": "warning",
+            "message": {"text": "issue"},
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {"uri": "foo.cc"},
+                        "region": {"startLine": 10, "startColumn": 1},
+                    }
+                }
+            ],
+            "ruleId": "some-check",
+        }
+        inp1 = self.p / "a.sarif"
+        inp2 = self.p / "b.sarif"
+        _write_sarif(inp1, [result])
+        _write_sarif(inp2, [result])  # exact duplicate — deduplication empties this run
+        out = self.p / "out.sarif"
+        merge_sarif_reports([inp1, inp2], out)
+        data = json.loads(out.read_text())
+        self.assertEqual(len(data["runs"]), 1)
+
+
+class TestCollectAndMergeSarif(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.p = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_finds_report_files_and_merges_them(self):
+        """Report files discovered via BEP are merged into the output SARIF file."""
+        report = self.p / "target.AspectRulesLintClangTidy.report"
+        _write_sarif(report, [{"message": {"text": "issue"}}], tool_name="ClangTidy")
+        bep = self.p / "bep.json"
+        _write_bep(bep, [report])
+        out = self.p / "out.sarif"
+
+        count = collect_and_merge_sarif(bep, out, bazel_output_path=self.p)
+
+        self.assertTrue(out.exists())
+        data = json.loads(out.read_text())
+        self.assertEqual(len(data["runs"]), 1)
+        self.assertEqual(count, 1)
+
+    def test_no_report_files_creates_empty_sarif(self):
+        """If the BEP lists no .report files, an empty but valid SARIF file is written."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write(json.dumps({"started": {"uuid": "x"}}) + "\n")
+        out = self.p / "out.sarif"
+
+        count = collect_and_merge_sarif(bep, out, bazel_output_path=self.p)
+
+        data = json.loads(out.read_text())
+        self.assertEqual(data["runs"], [])
+        self.assertEqual(count, 0)
+
+
+class TestCollectPatches(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.p = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_nonempty_patch_files_are_copied(self):
+        """Non-empty patch files listed in the BEP are copied to the output folder."""
+        patch_file = self.p / "fix.patch"
+        patch_file.write_text("--- a/file.cc\n+++ b/file.cc\n@@ -1 +1 @@\n-old\n+new\n")
+        bep = self.p / "bep.json"
+        _write_bep(bep, [patch_file])
+        out_dir = self.p / "patches"
+
+        collect_patches(bep, out_dir, bazel_output_path=self.p)
+
+        self.assertTrue((out_dir / "fix.patch").exists())
+        self.assertEqual((out_dir / "fix.patch").read_text(), patch_file.read_text())
+
+    def test_empty_patch_files_are_skipped(self):
+        """Zero-byte patch files are not copied to the output folder."""
+        empty_patch = self.p / "empty.patch"
+        empty_patch.touch()
+        bep = self.p / "bep.json"
+        _write_bep(bep, [empty_patch])
+        out_dir = self.p / "patches"
+
+        collect_patches(bep, out_dir, bazel_output_path=self.p)
+
+        self.assertFalse((out_dir / "empty.patch").exists())
+
+    def test_nonexistent_patch_files_are_skipped(self):
+        """Patch file paths that don't exist are silently skipped."""
+        bep = self.p / "bep.json"
+        _write_bep(bep, [self.p / "ghost.patch"])
+        out_dir = self.p / "patches"
+
+        collect_patches(bep, out_dir, bazel_output_path=self.p)
+
+        # Output dir may or may not be created; no files should be in it
+        if out_dir.exists():
+            self.assertEqual(list(out_dir.iterdir()), [])
+
+    def test_output_directory_is_created_if_missing(self):
+        """The output directory is created even if no patch files are copied."""
+        patch_file = self.p / "a.patch"
+        patch_file.write_text("diff content")
+        bep = self.p / "bep.json"
+        _write_bep(bep, [patch_file])
+        out_dir = self.p / "new" / "nested" / "patches"
+
+        collect_patches(bep, out_dir, bazel_output_path=self.p)
+
+        self.assertTrue(out_dir.exists())
+
+    def test_no_patch_files_in_bep_does_nothing(self):
+        """A BEP with no .patch entries results in an empty output directory."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write(
+                json.dumps(
+                    {
+                        "namedSetOfFiles": {
+                            "files": [
+                                {"name": "foo.report", "pathPrefix": ["/tmp"]},
+                            ]
+                        }
+                    }
+                )
+                + "\n"
+            )
+        out_dir = self.p / "patches"
+
+        collect_patches(bep, out_dir, bazel_output_path=self.p)
+
+        # Output dir is always created; it should be empty
+        self.assertTrue(out_dir.exists())
+        self.assertEqual(list(out_dir.iterdir()), [])
+
+
+class TestMain(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.p = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _make_bep_with_sarif(self, num_results: int, levels: list = None) -> tuple:
+        """Create a .report SARIF file and a BEP pointing to it. Returns (bep_path, output_path)."""
+        if levels is None:
+            results = [{"message": {"text": f"issue {i}"}} for i in range(num_results)]
+        else:
+            results = [
+                {"level": lvl, "message": {"text": f"issue {i}"}}
+                for i, lvl in enumerate(levels)
+            ]
+        report = self.p / "target.report"
+        _write_sarif(report, results)
+        bep = self.p / "bep.json"
+        _write_bep(bep, [report])
+        out = self.p / "merged.sarif"
+        return bep, out
+
+    def test_missing_bep_file_exits_with_code_1(self):
+        """A non-existent --build-event-json-file causes exit with code 1."""
+        with patch(
+            "sys.argv",
+            [
+                "extract_lint_results.py",
+                "--build-event-json-file",
+                str(self.p / "missing.json"),
+                "--bazel-output-path",
+                str(self.p),
+            ],
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_exit_code_triggered_when_errors_found(self):
+        """--exit-code N causes sys.exit(N) when total results > 0."""
+        bep, out = self._make_bep_with_sarif(num_results=2)
+        with patch(
+            "sys.argv",
+            [
+                "extract_lint_results.py",
+                "--build-event-json-file",
+                str(bep),
+                "--bazel-output-path",
+                str(self.p),
+                "--output-merged-sarif-file",
+                str(out),
+                "--exit-code",
+                "1",
+            ],
+        ):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_exit_code_not_triggered_when_no_results(self):
+        """--exit-code N does not call sys.exit when there are no results."""
+        bep, out = self._make_bep_with_sarif(num_results=0)
+        with patch(
+            "sys.argv",
+            [
+                "extract_lint_results.py",
+                "--build-event-json-file",
+                str(bep),
+                "--bazel-output-path",
+                str(self.p),
+                "--output-merged-sarif-file",
+                str(out),
+                "--exit-code",
+                "1",
+            ],
+        ):
+            main()  # must not raise
+
+    def test_output_patch_folder_collects_patches(self):
+        """--output-patch-folder causes non-empty patch files to be copied."""
+        patch_file = self.p / "fix.patch"
+        patch_file.write_text("--- a\n+++ b\n@@ -1 +1 @@\n")
+        bep = self.p / "bep.json"
+        _write_bep(bep, [patch_file])
+        patch_out = self.p / "collected_patches"
+
+        with patch(
+            "sys.argv",
+            [
+                "extract_lint_results.py",
+                "--build-event-json-file",
+                str(bep),
+                "--bazel-output-path",
+                str(self.p),
+                "--output-patch-folder",
+                str(patch_out),
+            ],
+        ):
+            main()
+
+        self.assertTrue((patch_out / "fix.patch").exists())
+
+    def test_no_output_file_argument_does_not_crash(self):
+        """Omitting --output-merged-sarif-file is allowed and causes no crash."""
+        bep = self.p / "bep.json"
+        with open(bep, "w") as f:
+            f.write(json.dumps({"started": {}}) + "\n")
+        with patch(
+            "sys.argv",
+            [
+                "extract_lint_results.py",
+                "--build-event-json-file",
+                str(bep),
+                "--bazel-output-path",
+                str(self.p),
+            ],
+        ):
+            main()  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add tooling, which reads SARIF reports from `rules_lint` and merges them, so that they can be easily processed by tooling like reviewdog.