### PR TITLE
Load `CcInfo`

### DIFF
--- a/cc_files/get_cc_files.bzl
+++ b/cc_files/get_cc_files.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//cc:defs.bzl", "BINARY", "LIBRARY", "TEST_LIBRARY", "TEST_SRCS")
 
 FilesInfo = provider(

--- a/check_attributes/check_attributes.bzl
+++ b/check_attributes/check_attributes.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//cc_files:get_cc_files.bzl", "get_cc_files")
 
 def _run_check_attributes(ctx, infile):

--- a/clang_format/clang_format_check.bzl
+++ b/clang_format/clang_format_check.bzl
@@ -1,3 +1,4 @@
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//cc_files:get_cc_files.bzl", "get_cc_files")
 
 def _check_format(ctx, exe, config, infile, clang_format_bin):

--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//cc:defs.bzl", "BINARY", "LIBRARY")
 load("//cc_files:get_cc_files.bzl", "get_cc_srcs")
 


### PR DESCRIPTION
Add more `load` statements for Bazel 9 compatibility.