### PR TITLE
Implement hermetic doxygen

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,6 +66,9 @@ use_repo(
 yocto_generic_ext = use_extension("@rules_swiftnav//cc/toolchains/yocto_generic:yocto_generic_extension.bzl", "yocto_generic_extension")
 use_repo(yocto_generic_ext, "yocto_generic")
 
+doxygen_ext = use_extension("@rules_swiftnav//doxygen:extensions.bzl", "doxygen_extension")
+use_repo(doxygen_ext, "doxygen_linux_x86_64", "doxygen_macos_arm64")
+
 # Register the buildifier toolchain
 bazel_dep(
     name = "buildifier_prebuilt",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -382,7 +382,7 @@
     "//cc/toolchains/yocto_generic:yocto_generic_extension.bzl%yocto_generic_extension": {
       "general": {
         "bzlTransitiveDigest": "Q4v/HN5Wh/W0JsPpeExQzSqIslfepuWsd75kvW+25FI=",
-        "usagesDigest": "c1pdCjr4m4AYUD9I8UZRn8wzSwJ6pN6KLN5r0+2dZ/E=",
+        "usagesDigest": "kq8xM81FZzxLe7/KhyWMH6TbWKr+YoPvTeG+zjTqXhE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -393,6 +393,46 @@
           }
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "//doxygen:extensions.bzl%doxygen_extension": {
+      "general": {
+        "bzlTransitiveDigest": "8rXZSW6xn9yZRmIS3aOLg3oOm71ghtrkPoU8tme9a0A=",
+        "usagesDigest": "qfqAVlrrWkDLEdM8ZBxhcmuwJmaSbrF5D1plABuXSgE=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "doxygen_linux_x86_64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0.linux.bin.tar.gz"
+              ],
+              "sha256": "75419ef4f446fc1c24ef12514b574e66e898ee6f527c6ae2ad84f91a905823c2",
+              "strip_prefix": "doxygen-1.17.0",
+              "build_file": "@@//doxygen:doxygen_linux.BUILD"
+            }
+          },
+          "doxygen_macos_arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "urls": [
+                "https://github.com/doxygen/doxygen/releases/download/Release_1_17_0/doxygen-1.17.0-mac-arm.zip"
+              ],
+              "sha256": "e05a7f647f894d2d82ef26a1d231cda079d2d1d85cf1e1c6fd8072430d80d614",
+              "strip_prefix": "doxygen-1.17.0",
+              "build_file": "@@//doxygen:doxygen_macos.BUILD"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
       }
     },
     "@@pybind11_bazel+//:python_configure.bzl%extension": {

--- a/doxygen/BUILD.bazel
+++ b/doxygen/BUILD.bazel
@@ -8,14 +8,6 @@ alias(
     }),
 )
 
-alias(
-    name = "doxygen_runtime_files",
-    actual = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@doxygen_linux_x86_64//:runtime_files",
-        "@bazel_tools//src/conditions:darwin_arm64": "@doxygen_macos_arm64//:runtime_files",
-    }),
-)
-
 exports_files(
     [
         "doxygen_linux.BUILD",

--- a/doxygen/BUILD.bazel
+++ b/doxygen/BUILD.bazel
@@ -1,21 +1,18 @@
 package(default_visibility = ["//visibility:public"])
 
-# Hermetic Doxygen binary, downloaded by the doxygen_extension in
-# //doxygen:extensions.bzl. No PATH fallback — building on an unsupported host
-# fails at analysis time, by design.
 alias(
     name = "doxygen",
     actual = select({
-        "@platforms//os:linux": "@doxygen_linux_x86_64//:doxygen_bin",
-        "@platforms//os:macos": "@doxygen_macos_arm64//:doxygen_bin",
+        "@bazel_tools//src/conditions:linux_x86_64": "@doxygen_linux_x86_64//:doxygen_bin",
+        "@bazel_tools//src/conditions:darwin_arm64": "@doxygen_macos_arm64//:doxygen_bin",
     }),
 )
 
 alias(
     name = "doxygen_runtime_files",
     actual = select({
-        "@platforms//os:linux": "@doxygen_linux_x86_64//:runtime_files",
-        "@platforms//os:macos": "@doxygen_macos_arm64//:runtime_files",
+        "@bazel_tools//src/conditions:linux_x86_64": "@doxygen_linux_x86_64//:runtime_files",
+        "@bazel_tools//src/conditions:darwin_arm64": "@doxygen_macos_arm64//:runtime_files",
     }),
 )
 

--- a/doxygen/BUILD.bazel
+++ b/doxygen/BUILD.bazel
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+# Hermetic Doxygen binary, downloaded by the doxygen_extension in
+# //doxygen:extensions.bzl. No PATH fallback — building on an unsupported host
+# fails at analysis time, by design.
+alias(
+    name = "doxygen",
+    actual = select({
+        "@platforms//os:linux": "@doxygen_linux_x86_64//:doxygen_bin",
+        "@platforms//os:macos": "@doxygen_macos_arm64//:doxygen_bin",
+    }),
+)
+
+alias(
+    name = "doxygen_runtime_files",
+    actual = select({
+        "@platforms//os:linux": "@doxygen_linux_x86_64//:runtime_files",
+        "@platforms//os:macos": "@doxygen_macos_arm64//:runtime_files",
+    }),
+)
+
+exports_files(
+    [
+        "doxygen_linux.BUILD",
+        "doxygen_macos.BUILD",
+    ],
+)

--- a/doxygen/BUILD.bazel
+++ b/doxygen/BUILD.bazel
@@ -2,10 +2,14 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "doxygen",
-    actual = select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@doxygen_linux_x86_64//:doxygen_bin",
-        "@bazel_tools//src/conditions:darwin_arm64": "@doxygen_macos_arm64//:doxygen_bin",
-    }),
+    actual = select(
+        {
+            "@bazel_tools//src/conditions:linux_x86_64": "@doxygen_linux_x86_64//:doxygen_bin",
+            "@bazel_tools//src/conditions:darwin_arm64": "@doxygen_macos_arm64//:doxygen_bin",
+        },
+        no_match_error = "Hermetic Doxygen is only available on linux_x86_64 and darwin_arm64. " +
+                         "darwin_x86_64 (Intel macOS) and other hosts are not supported.",
+    ),
 )
 
 exports_files(

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -2,7 +2,7 @@
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -25,8 +25,11 @@ def _swift_doxygen_impl(ctx):
     # when --stamp is enabled. Contains STABLE_GIT_TAG and other workspace status values.
     info_file = ctx.info_file
 
+    doxygen_bin = ctx.file._doxygen
+
     ctx.actions.run_shell(
         inputs = [config, info_file] + ctx.files.deps,
+        tools = [doxygen_bin],
         outputs = [doxygen_out],
         env = vars,
         command = """
@@ -40,7 +43,7 @@ def _swift_doxygen_impl(ctx):
 
         EXEC_ROOT=$(pwd)
 
-        # Use the GIT TAG 
+        # Use the GIT TAG
         STABLE_GIT_TAG=$(grep -m1 '^STABLE_GIT_TAG ' {info_file} | cut -d' ' -f2-)
 
         # Apply backward compatibility sed replacements into a temp file within
@@ -54,8 +57,12 @@ def _swift_doxygen_impl(ctx):
         sed "s|@DOXYGEN_EXCLUDE@|$DOXYGEN_EXCLUDE|g" | \
         sed "s|@PROJECT_SOURCE_DIR@|$EXEC_ROOT|g" > _processed_Doxyfile
 
-        PATH=$PATH doxygen _processed_Doxyfile
-        """.format(original_config = config.path, info_file = info_file.path),
+        "$EXEC_ROOT/{doxygen_bin}" _processed_Doxyfile
+        """.format(
+            original_config = config.path,
+            info_file = info_file.path,
+            doxygen_bin = doxygen_bin.path,
+        ),
     )
 
     return [DefaultInfo(files = depset([doxygen_out, config]))]
@@ -70,6 +77,11 @@ _swift_doxygen = rule(
         ),
         "deps": attr.label_list(),
         "doxygen_source_directories": attr.string_list(),
+        "_doxygen": attr.label(
+            default = "@rules_swiftnav//doxygen:doxygen",
+            allow_single_file = True,
+            cfg = "exec",
+        ),
     },
 )
 

--- a/doxygen/doxygen_linux.BUILD
+++ b/doxygen/doxygen_linux.BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "doxygen_bin",
+    srcs = ["bin/doxygen"],
+)
+
+filegroup(
+    name = "runtime_files",
+    srcs = glob(["**"]),
+)

--- a/doxygen/doxygen_linux.BUILD
+++ b/doxygen/doxygen_linux.BUILD
@@ -4,8 +4,3 @@ filegroup(
     name = "doxygen_bin",
     srcs = ["bin/doxygen"],
 )
-
-filegroup(
-    name = "runtime_files",
-    srcs = glob(["**"]),
-)

--- a/doxygen/doxygen_macos.BUILD
+++ b/doxygen/doxygen_macos.BUILD
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "doxygen_bin",
+    srcs = ["doxygen"],
+)
+
+filegroup(
+    name = "runtime_files",
+    srcs = glob(["**"]),
+)

--- a/doxygen/doxygen_macos.BUILD
+++ b/doxygen/doxygen_macos.BUILD
@@ -4,8 +4,3 @@ filegroup(
     name = "doxygen_bin",
     srcs = ["doxygen"],
 )
-
-filegroup(
-    name = "runtime_files",
-    srcs = glob(["**"]),
-)

--- a/doxygen/extensions.bzl
+++ b/doxygen/extensions.bzl
@@ -1,0 +1,40 @@
+# Copyright (C) 2026 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+
+"""Module extension that fetches hermetic Doxygen binaries from upstream GitHub releases."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+_DOXYGEN_VERSION = "1.17.0"
+_DOXYGEN_RELEASE = "Release_1_17_0"
+_BASE_URL = "https://github.com/doxygen/doxygen/releases/download/" + _DOXYGEN_RELEASE
+
+_DOXYGEN_ARCHIVES = {
+    "doxygen_linux_x86_64": struct(
+        asset = "doxygen-{v}.linux.bin.tar.gz".format(v = _DOXYGEN_VERSION),
+        strip_prefix = "doxygen-{v}".format(v = _DOXYGEN_VERSION),
+        build_file = "@rules_swiftnav//doxygen:doxygen_linux.BUILD",
+        sha256 = "75419ef4f446fc1c24ef12514b574e66e898ee6f527c6ae2ad84f91a905823c2",
+    ),
+    "doxygen_macos_arm64": struct(
+        asset = "doxygen-{v}-mac-arm.zip".format(v = _DOXYGEN_VERSION),
+        strip_prefix = "doxygen-{v}".format(v = _DOXYGEN_VERSION),
+        build_file = "@rules_swiftnav//doxygen:doxygen_macos.BUILD",
+        sha256 = "e05a7f647f894d2d82ef26a1d231cda079d2d1d85cf1e1c6fd8072430d80d614",
+    ),
+}
+
+def _doxygen_extension_impl(_ctx):
+    for repo_name, spec in _DOXYGEN_ARCHIVES.items():
+        http_archive(
+            name = repo_name,
+            urls = ["{base}/{asset}".format(base = _BASE_URL, asset = spec.asset)],
+            sha256 = spec.sha256,
+            strip_prefix = spec.strip_prefix,
+            build_file = spec.build_file,
+        )
+
+doxygen_extension = module_extension(implementation = _doxygen_extension_impl)


### PR DESCRIPTION
Implement hermetic doxygen which allows out-of-the-box execution on both Linux and Mac.
This additionally adds a dependency of the generated doxygen output to the doxygen executables so that version updates of doxygen force a rebuild of the documentation.