### PR TITLE
Resolve strip tool via toolchain action config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,3 +38,24 @@ jobs:
           cd examples/small_world
           bazel run //tools/buildifier:buildifier
           git diff --exit-code
+
+  strip-macos:
+    # Guards the strip rule against Mach-O regressions: llvm-strip rejects
+    # several ELF-only options on macOS, so this exercises the same strip()
+    # target that bird-sweater relies on. The Linux job above cannot catch a
+    # Mach-O-only flag regression.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Build and test strip example
+        run: |
+          cd examples/small_world
+          bazel test //src/strip_tool/...

--- a/cc/strip.bzl
+++ b/cc/strip.bzl
@@ -2,10 +2,31 @@ load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
+# llvm-strip rejects these ELF-only options when operating on a Mach-O object
+# ("option is not supported for MachO"). They have no symbol-stripping effect
+# worth preserving, so drop them on macOS.
+_MACHO_UNSUPPORTED_STRIPOPTS = [
+    "-p",
+    "--preserve-dates",
+]
+
+# Translate ELF-only symbol-stripping options to their nearest Mach-O equivalent
+# so the same strip() target removes comparable symbols on both platforms. The
+# stripping protects shipped symbols, so we keep parity of intent rather than
+# silently stripping less on macOS.
+_MACHO_STRIPOPT_EQUIVALENTS = {
+    # `--strip-unneeded` removes symbols not needed for relocations on ELF; `-x`
+    # strips local (internal) symbols, the closest Mach-O equivalent.
+    "--strip-unneeded": "-x",
+}
+
 def _strip_impl(ctx):
     binary = ctx.file.binary
     out = ctx.actions.declare_file(ctx.attr.name)
     cc_toolchain = find_cpp_toolchain(ctx)
+    is_macos = ctx.target_platform_has_constraint(
+        ctx.attr._macos[platform_common.ConstraintValueInfo],
+    )
 
     # Resolve the strip tool through the toolchain's action config rather than the
     # legacy `cc_toolchain.strip_executable` field. Toolchains built on the modern
@@ -25,11 +46,25 @@ def _strip_impl(ctx):
 
     args = ctx.actions.args()
     args.add("-S")
-    args.add("-p")
+
+    # `-p` (preserve dates) is an ELF-only option that llvm-strip rejects for
+    # Mach-O. Keep it for ELF targets, drop it on macOS.
+    if not is_macos:
+        args.add("-p")
+
     args.add("-o")
     args.add(out)
     args.add(binary)
-    [args.add(opt) for opt in ctx.attr.stripopts]
+
+    for opt in ctx.attr.stripopts:
+        if is_macos:
+            equivalent = _MACHO_STRIPOPT_EQUIVALENTS.get(opt)
+            if equivalent:
+                args.add(equivalent)
+                continue
+            if opt in _MACHO_UNSUPPORTED_STRIPOPTS:
+                continue
+        args.add(opt)
 
     ctx.actions.run(
         outputs = [out],
@@ -49,6 +84,9 @@ strip = rule(
         "stripopts": attr.string_list(),
         "_cc_toolchain": attr.label(
             default = "@bazel_tools//tools/cpp:current_cc_toolchain",
+        ),
+        "_macos": attr.label(
+            default = "@platforms//os:macos",
         ),
     },
     executable = True,

--- a/cc/strip.bzl
+++ b/cc/strip.bzl
@@ -1,10 +1,27 @@
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 
 def _strip_impl(ctx):
     binary = ctx.file.binary
     out = ctx.actions.declare_file(ctx.attr.name)
     cc_toolchain = find_cpp_toolchain(ctx)
-    strip = cc_toolchain.strip_executable
+
+    # Resolve the strip tool through the toolchain's action config rather than the
+    # legacy `cc_toolchain.strip_executable` field. Toolchains built on the modern
+    # rules_cc API (e.g. the rules_rs hermetic LLVM toolchain) only wire `strip`
+    # through the action config and leave `strip_executable` pointing at a path
+    # that is never materialized, which fails at execution with "No such file".
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+    strip = cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = ACTION_NAMES.strip,
+    )
 
     args = ctx.actions.args()
     args.add("-S")
@@ -16,7 +33,7 @@ def _strip_impl(ctx):
 
     ctx.actions.run(
         outputs = [out],
-        inputs = [binary] + cc_toolchain.all_files.to_list(),
+        inputs = depset([binary], transitive = [cc_toolchain.all_files]),
         executable = strip,
         arguments = [args],
         mnemonic = "Strip",
@@ -36,4 +53,5 @@ strip = rule(
     },
     executable = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
 )

--- a/examples/small_world/MODULE.bazel
+++ b/examples/small_world/MODULE.bazel
@@ -2,6 +2,7 @@ module(name = "small_world")
 
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_swiftnav")
 local_path_override(
     module_name = "rules_swiftnav",

--- a/examples/small_world/src/strip_tool/BUILD.bazel
+++ b/examples/small_world/src/strip_tool/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_swiftnav//cc:strip.bzl", "strip")
+
+cc_binary(
+    name = "hello",
+    srcs = ["hello.cc"],
+)
+
+# Regression test for the strip rule resolving its tool via the toolchain action
+# config: modern rules_cc toolchains (e.g. the swift llvm toolchains) leave the
+# legacy cc_toolchain.strip_executable unpopulated, which used to fail at exec time.
+strip(
+    name = "hello_stripped",
+    binary = ":hello",
+    stripopts = ["--strip-unneeded"],
+)
+
+build_test(
+    name = "strip_build_test",
+    targets = [":hello_stripped"],
+)

--- a/examples/small_world/src/strip_tool/BUILD.bazel
+++ b/examples/small_world/src/strip_tool/BUILD.bazel
@@ -7,9 +7,13 @@ cc_binary(
     srcs = ["hello.cc"],
 )
 
-# Regression test for the strip rule resolving its tool via the toolchain action
-# config: modern rules_cc toolchains (e.g. the swift llvm toolchains) leave the
-# legacy cc_toolchain.strip_executable unpopulated, which used to fail at exec time.
+# Regression test for the strip rule, mirroring bird-sweater's usage. Guards two
+# things, on both Linux (ELF) and macOS (Mach-O) via CI:
+#   1. Tool resolution: modern rules_cc toolchains (e.g. the swift llvm toolchains)
+#      leave the legacy cc_toolchain.strip_executable unpopulated, which used to
+#      fail at exec time.
+#   2. Mach-O flags: llvm-strip rejects ELF-only options like --strip-unneeded for
+#      Mach-O, so the rule must drop them on macOS.
 strip(
     name = "hello_stripped",
     binary = ":hello",

--- a/examples/small_world/src/strip_tool/hello.cc
+++ b/examples/small_world/src/strip_tool/hello.cc
@@ -1,0 +1,1 @@
+int main() { return 0; }


### PR DESCRIPTION
## Problem

The `strip` rule (`//cc:strip.bzl`) resolves its tool from `cc_toolchain.strip_executable` — the **legacy** `ToolchainInfo` field. Toolchains built on the modern rules_cc API (the swift `*-llvm20` toolchains, and the rules_rs hermetic LLVM toolchain) only wire the `strip` action through the action config and leave `strip_executable` pointing at a path that is never materialized. The action then fails at execution:

```
external/llvm+/toolchain/strip -S -p -o ... --strip-unneeded
execvp(external/llvm+/toolchain/strip, ...): No such file or directory
```

Toolchains that still set `strip_executable` (e.g. the musl SDK toolchains) work, which is why this only surfaced when consuming the LLVM toolchain (in `bird-sweater`'s rules_rs migration).

Separately, the rule only ever worked on Linux/ELF: it hardcodes `-p` and consumers pass `--strip-unneeded`, both of which are **ELF-only** options that `llvm-strip` rejects for Mach-O (`option is not supported for MachO`). `bird-sweater` needs to build on macOS as well as Linux.

## Fix

**Tool resolution.** Resolve the tool with `cc_common.get_tool_for_action(ACTION_NAMES.strip)` against a `configure_features` feature configuration. This reads the toolchain's action config and works for **both** the legacy `tool_paths`-based toolchains and the modern action-config toolchains (it returns `llvm-strip` for the LLVM toolchains and the SDK `*-strip` for the musl toolchains).

**macOS / Mach-O.** Make the flags platform-aware (still using the toolchain's `llvm-strip` — no switch to rustc strip):
- **Linux/ELF: byte-for-byte unchanged** — `llvm-strip -S -p -o OUT IN --strip-unneeded`.
- **macOS/Mach-O:** drop `-p` (preserve-dates; no symbol-stripping effect), and translate `--strip-unneeded` → `-x` so local/internal symbols are still stripped. Stripping protects shipped symbols, so we keep parity of *intent* rather than silently stripping less on macOS.

Consumers (bird-sweater) need no BUILD changes — the rule handles the platform difference.

## Test

`examples/small_world/src/strip_tool` — a `cc_binary` + `strip` + `build_test`, mirroring bird-sweater's usage (`stripopts = ["--strip-unneeded"]`). The example uses the swift LLVM toolchains (modern API), so it exercises exactly the path that was broken.

- The existing **ubuntu** job builds it via `bazel coverage //...` (ELF tool-resolution guard).
- A new **macos-latest** job runs `bazel test //src/strip_tool/...` (Mach-O flag guard). The ubuntu-only setup could not catch a Mach-O-only flag regression — which is how a rules_swiftnav change can silently break a downstream macOS build.

Verified locally on macOS: the strip action runs (`llvm-strip -S -o OUT IN -x`) and the stripped binary executes.
