### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+name: release
+
+# Cuts a release when MODULE.bazel's version changes on a push to main.
+#
+# NOTE: this job creates the tag + GitHub release using the built-in
+# GITHUB_TOKEN. Events created with GITHUB_TOKEN do NOT trigger other
+# workflow runs (GitHub's recursion guard). That is fine today: nothing
+# in this repo listens for the tag/release event, and downstream
+# publishing is handled out-of-band by a separate manual process. If a
+# future workflow is added `on: release` or `on: push: tags` (e.g. to
+# build/upload release assets), it will NOT be triggered by this job —
+# switch the release creation below to a GitHub App token at that point.
+
+on:
+  push:
+    branches:
+      - 'main'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Don't cut releases from forks of this public repo.
+    if: github.repository == 'swift-nav/rules_swiftnav'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          # Full history so we can read MODULE.bazel at the previous main tip
+          # (github.event.before), which is robust to multi-commit pushes.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect version change and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          NEW=$(python3 tools/release.py --current)
+          if [ -z "$NEW" ]; then
+            echo "could not read current version from MODULE.bazel" >&2
+            exit 1
+          fi
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "no previous main tip to compare against; nothing to release"
+            exit 0
+          fi
+          OLD=$(git show "$BEFORE:MODULE.bazel" | python3 tools/release.py --current --stdin)
+          if [ "$NEW" = "$OLD" ]; then
+            echo "version unchanged ($NEW); nothing to release"
+            exit 0
+          fi
+          TAG="v$NEW"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG already exists; nothing to do"
+            exit 0
+          fi
+          echo "releasing $OLD -> $NEW as $TAG"
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Full history so we can read MODULE.bazel at the previous main tip
           # (github.event.before), which is robust to multi-commit pushes.
@@ -38,6 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BEFORE: ${{ github.event.before }}
         run: |
+          set -euo pipefail
           NEW=$(python3 tools/release.py --current)
           if [ -z "$NEW" ]; then
             echo "could not read current version from MODULE.bazel" >&2
@@ -47,7 +48,13 @@ jobs:
             echo "no previous main tip to compare against; nothing to release"
             exit 0
           fi
-          OLD=$(git show "$BEFORE:MODULE.bazel" | python3 tools/release.py --current --stdin)
+          # Tolerate MODULE.bazel not existing at $BEFORE (e.g. history rewrite):
+          # an unreadable previous version must not be mistaken for a change.
+          OLD=$(git show "$BEFORE:MODULE.bazel" 2>/dev/null | python3 tools/release.py --current --stdin) || true
+          if [ -z "$OLD" ]; then
+            echo "could not read previous version (MODULE.bazel missing at $BEFORE?); nothing to release"
+            exit 0
+          fi
           if [ "$NEW" = "$OLD" ]; then
             echo "version unchanged ($NEW); nothing to release"
             exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bazel-*
+__pycache__/
+*.pyc

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/defs.bzl
+++ b/cc/defs.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/fix_include_guards.py
+++ b/cc/fix_include_guards.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2023 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
@@ -120,7 +120,7 @@ def fix_header_guard(filename):
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
- * be be distributed together with this source. All other rights reserved.
+ * be distributed together with this source. All other rights reserved.
  *
  * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/repositories.bzl
+++ b/cc/repositories.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_embedded/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
+++ b/cc/toolchains/gcc_arm_gnu_8_3/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/BUILD.bazel
+++ b/cc/toolchains/llvm/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-darwin/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-darwin/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/aarch64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/aarch64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm/cc_toolchain_config.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/llvm.BUILD.bzl
+++ b/cc/toolchains/llvm/llvm.BUILD.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-aarch64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-darwin/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-darwin/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm/x86_64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm/x86_64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/BUILD.bazel
+++ b/cc/toolchains/llvm20/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/aarch64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm20/aarch64-darwin/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-darwin/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/aarch64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/aarch64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm20/cc_toolchain_config.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/llvm.BUILD.bzl
+++ b/cc/toolchains/llvm20/llvm.BUILD.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-aarch64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-darwin/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-darwin/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-darwin/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
+++ b/cc/toolchains/llvm20/x86_64-linux/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
+++ b/cc/toolchains/llvm20/x86_64-linux/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2025 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
+++ b/cc/toolchains/llvm_x86_64_windows/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2024 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/wrappers
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ar
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-as
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-clang
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-cpp
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-g++
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcc
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-gcov
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ld
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-nm
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objcopy
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-objdump
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-ranlib
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
+++ b/cc/toolchains/llvm_x86_64_windows/wrappers/x86_64-w64-mingw32uwp-strip
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/musl/aarch64/wrappers/wrapper
+++ b/cc/toolchains/musl/aarch64/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/musl/armhf/wrappers/wrapper
+++ b/cc/toolchains/musl/armhf/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/toolchains/musl/x86_64/wrappers/wrapper
+++ b/cc/toolchains/musl/x86_64/wrappers/wrapper
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/cc/utils.bzl
+++ b/cc/utils.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -15,6 +15,11 @@ the copyright headers across the repo to the current year (e.g. `2022-2025` ->
 preview the next version and how many headers would change without making any
 changes.
 
+Run it through `bazelisk` (the repo's `bazel` wrapper) so the example lockfile is
+regenerated with the Bazel version pinned in `.bazeliskrc` — the same version CI
+uses to validate it. The tool refuses to run if the active Bazel version differs
+from that pin, since a mismatch would desync the lockfile digest from CI.
+
 Review and merge the PR as normal.
 
 ## 2. (automatic) Tag + GitHub release

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,9 +9,11 @@ created automatically.
 bazel run //tools:release -- minor   # or: major / patch
 ```
 
-This bumps `version` in `MODULE.bazel`, refreshes the example lockfile, and opens
-a PR titled `Bump version to X.Y.Z`. Use `--dry-run` to preview the next version
-without making changes.
+This bumps `version` in `MODULE.bazel`, refreshes the example lockfile, extends
+the copyright headers across the repo to the current year (e.g. `2022-2025` ->
+`2022-2026`), and opens a PR titled `Bump version to X.Y.Z`. Use `--dry-run` to
+preview the next version and how many headers would change without making any
+changes.
 
 Review and merge the PR as normal.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,28 @@
+# Releasing
+
+Cutting a release is two steps for a maintainer; the tag and GitHub release are
+created automatically.
+
+## 1. Open the release PR
+
+```bash
+bazel run //tools:release -- minor   # or: major / patch
+```
+
+This bumps `version` in `MODULE.bazel`, refreshes the example lockfile, and opens
+a PR titled `Bump version to X.Y.Z`. Use `--dry-run` to preview the next version
+without making changes.
+
+Review and merge the PR as normal.
+
+## 2. (automatic) Tag + GitHub release
+
+On merge to `main`, `.github/workflows/release.yaml` detects the `MODULE.bazel`
+version change and creates the `vX.Y.Z` tag plus a GitHub release. Nothing to do.
+
+## 3. Publish to the Bazel registry
+
+The module is consumed via a separate Bazel registry. After the tag exists, run
+the registry's sync tool from a checkout of that repository to stage and open the
+registry PR — see that repository's README for the exact command. This step is
+manual by design: it lives in a separate repository and is not driven from here.

--- a/doxygen/doxygen.bzl
+++ b/doxygen/doxygen.bzl
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must

--- a/doxygen/extensions.bzl
+++ b/doxygen/extensions.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2026 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 
 """Module extension that fetches hermetic Doxygen binaries from upstream GitHub releases."""
 

--- a/examples/small_world/MODULE.bazel.lock
+++ b/examples/small_world/MODULE.bazel.lock
@@ -504,7 +504,7 @@
     },
     "@@rules_swiftnav+//cc:extensions.bzl%swift_cc_toolchain_extension": {
       "general": {
-        "bzlTransitiveDigest": "RsF8sHHXc6ZZgh3R7L2QSEdkSNO2p45Yo1bkKHqjBWw=",
+        "bzlTransitiveDigest": "LS0VF7klVv3uKgNzF7w5juh0eLqMf5RfufyCxD5bY3g=",
         "usagesDigest": "l1u4WK5qiCl3K1So4ni9gwrOFYuqHwgZc3lET8gZqD0=",
         "recordedInputs": [
           "REPO_MAPPING:rules_swiftnav+,bazel_tools bazel_tools",

--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/third_party/asio-grpc.BUILD
+++ b/third_party/asio-grpc.BUILD
@@ -1,8 +1,8 @@
-# Copyright (C) 2023 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/third_party/asio.BUILD
+++ b/third_party/asio.BUILD
@@ -1,8 +1,8 @@
-# Copyright (C) 2023 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -9,6 +9,9 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_test.bzl", "py_test")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT")
 
 exports_files(
     glob(["*.bzl"]),
@@ -19,4 +22,22 @@ string_flag(
     name = "root_dir",
     build_setting_default = "",
     visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "release",
+    srcs = ["release.py"],
+    main = "release.py",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "release_test",
+    srcs = [
+        "release.py",
+        "release_test.py",
+    ],
+    main = "release_test.py",
+    tags = [UNIT],
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/tools/configure_file.bzl
+++ b/tools/configure_file.bzl
@@ -1,8 +1,8 @@
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
@@ -14,6 +14,7 @@ Stdlib-only so CI can run it with plain `python3` (no Bazel/deps required).
 """
 
 import argparse
+import datetime
 import os
 import re
 import subprocess
@@ -21,6 +22,12 @@ import sys
 
 _VERSION_RE = re.compile(r'(?m)^(\s*version\s*=\s*")(\d+\.\d+\.\d+)(")')
 _PARTS = ("major", "minor", "patch")
+
+# Matches "Copyright (C) 2022" or "Copyright (C) 2022-2025" in a Swift
+# Navigation header, capturing the start year and (optional) end year.
+_COPYRIGHT_RE = re.compile(
+    r"(Copyright \(C\) )(\d{4})(?:-(\d{4}))?( Swift Navigation)"
+)
 
 REPO = "swift-nav/rules_swiftnav"
 EXAMPLE_LOCK_DIR = "examples/small_world"
@@ -52,6 +59,49 @@ def set_version(module_text, new_version):
     if n != 1:
         raise ValueError("could not substitute version in MODULE.bazel")
     return new_text
+
+
+def set_copyright_years(text, year):
+    """Return text with Swift Navigation copyright headers extended to year.
+
+    The first-publication year is preserved and the end of the range is set to
+    `year`, producing "(C) <start>-<year>". A header already ending at `year`
+    (single year or range) is left unchanged, so the transform is idempotent.
+    """
+    def repl(m):
+        start = int(m.group(2))
+        if start >= year:
+            return m.group(0)
+        return f"{m.group(1)}{start}-{year}{m.group(4)}"
+
+    return _COPYRIGHT_RE.sub(repl, text)
+
+
+def list_tracked_files():
+    """Return the repo's git-tracked file paths (relative to the workspace)."""
+    return _git_out(["ls-files"]).splitlines()
+
+
+def bump_copyrights(year, dry_run=False):
+    """Extend Swift Navigation copyright headers in tracked files to `year`.
+
+    Returns the list of files that changed (or would change, when dry_run).
+    Binary or non-UTF-8 files are skipped.
+    """
+    changed = []
+    for path in list_tracked_files():
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        new_text = set_copyright_years(text, year)
+        if new_text != text:
+            changed.append(path)
+            if not dry_run:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(new_text)
+    return changed
 
 
 def read_current_version(path="MODULE.bazel", use_stdin=False):
@@ -104,13 +154,20 @@ def main(argv=None):
     if existing_tags:
         raise SystemExit(f"tag {tag} already exists")
 
+    year = datetime.date.today().year
+
     if args.dry_run:
+        stale = bump_copyrights(year, dry_run=True)
         print(f"[dry-run] {old} -> {new} (branch {branch}, tag {tag})")
+        print(f"[dry-run] would bump copyright year to {year} in {len(stale)} file(s)")
         return 0
 
     try:
         with open(args.file, "w", encoding="utf-8") as f:
             f.write(set_version(text, new))
+
+        # Refresh copyright headers to the current year across the repo.
+        bumped = bump_copyrights(year)
 
         # Keep the committed example lockfile in sync with the bumped version.
         _run(["bazel", "mod", "deps", "--lockfile_mode=update"], cwd=EXAMPLE_LOCK_DIR)
@@ -118,7 +175,8 @@ def main(argv=None):
         _run(["bazel", "run", "//tools/buildifier:buildifier"])
 
         _run(["git", "checkout", "-b", branch])
-        _run(["git", "add", "MODULE.bazel", f"{EXAMPLE_LOCK_DIR}/MODULE.bazel.lock"])
+        _run(["git", "add", "MODULE.bazel", f"{EXAMPLE_LOCK_DIR}/MODULE.bazel.lock",
+              *bumped])
         _run(["git", "commit", "-m", f"Bump version to {new}"])
         _run(["git", "push", "-u", "origin", branch])
         _run(["gh", "pr", "create", "--repo", REPO, "--fill",
@@ -129,7 +187,7 @@ def main(argv=None):
         print(
             f"release failed mid-way. To reset:\n"
             f"  git checkout main && git branch -D {branch} 2>/dev/null; "
-            f"git checkout -- {args.file} {EXAMPLE_LOCK_DIR}/MODULE.bazel.lock",
+            f"git checkout -- .",
             file=sys.stderr,
         )
         raise

--- a/tools/release.py
+++ b/tools/release.py
@@ -32,6 +32,10 @@ _COPYRIGHT_RE = re.compile(
 REPO = "swift-nav/rules_swiftnav"
 EXAMPLE_LOCK_DIR = "examples/small_world"
 
+_BAZELISK_PIN_RE = re.compile(r'(?m)^\s*USE_BAZEL_VERSION\s*=\s*(\S+)')
+_BAZEL_VERSION_RE = re.compile(r'\bbazel\s+(\d+\.\d+\.\d+)')
+_CONCRETE_VERSION_RE = re.compile(r'\d+\.\d+\.\d+')
+
 
 def parse_version(module_text):
     """Return the X.Y.Z version string from a MODULE.bazel module() block."""
@@ -104,6 +108,40 @@ def bump_copyrights(year, dry_run=False):
     return changed
 
 
+def parse_bazelisk_pin(text):
+    """Return the USE_BAZEL_VERSION pinned in a .bazeliskrc, or None."""
+    m = _BAZELISK_PIN_RE.search(text)
+    return m.group(1) if m else None
+
+
+def parse_bazel_version(output):
+    """Return the X.Y.Z version from `bazel --version` output, or None."""
+    m = _BAZEL_VERSION_RE.search(output)
+    return m.group(1) if m else None
+
+
+def check_pinned_bazel(pin, version_output):
+    """Fail unless the running Bazel matches the .bazeliskrc `pin`.
+
+    The example lockfile's bzlTransitiveDigest is Bazel-version-specific, and CI
+    builds the example with the version bazelisk resolves from .bazeliskrc. A
+    release cut with a `bazel` that bypassed bazelisk (or overrode
+    USE_BAZEL_VERSION) would regenerate the lockfile with a different version,
+    desyncing the digest from CI. No-op when `pin` is not a concrete X.Y.Z
+    version (nothing to enforce against).
+    """
+    if not pin or not _CONCRETE_VERSION_RE.fullmatch(pin):
+        return
+    actual = parse_bazel_version(version_output)
+    if actual != pin:
+        raise SystemExit(
+            f"release must use the pinned Bazel {pin} (from .bazeliskrc), but "
+            f"`bazel --version` reports {actual or version_output.strip()!r}. "
+            f"Cut the release through bazelisk (and without a USE_BAZEL_VERSION "
+            f"override) so the example lockfile digest matches CI."
+        )
+
+
 def read_current_version(path="MODULE.bazel", use_stdin=False):
     """Read MODULE.bazel (from path or stdin) and return its version."""
     text = sys.stdin.read() if use_stdin else open(path, encoding="utf-8").read()
@@ -161,6 +199,15 @@ def main(argv=None):
         print(f"[dry-run] {old} -> {new} (branch {branch}, tag {tag})")
         print(f"[dry-run] would bump copyright year to {year} in {len(stale)} file(s)")
         return 0
+
+    # The example lockfile is regenerated below; ensure we'll do so with the
+    # same Bazel version CI uses, i.e. that bazelisk honored .bazeliskrc.
+    rc_path = os.path.join(EXAMPLE_LOCK_DIR, ".bazeliskrc")
+    pin = parse_bazelisk_pin(open(rc_path, encoding="utf-8").read()) \
+        if os.path.exists(rc_path) else None
+    bazel_version = subprocess.run(["bazel", "--version"], cwd=EXAMPLE_LOCK_DIR,
+                                   text=True, capture_output=True).stdout
+    check_pinned_bazel(pin, bazel_version)
 
     try:
         with open(args.file, "w", encoding="utf-8") as f:

--- a/tools/release.py
+++ b/tools/release.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+"""Bump the rules_swiftnav module version and open a release PR.
+
+Stdlib-only so CI can run it with plain `python3` (no Bazel/deps required).
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+_VERSION_RE = re.compile(r'(?m)^(\s*version\s*=\s*")(\d+\.\d+\.\d+)(")')
+_PARTS = ("major", "minor", "patch")
+
+REPO = "swift-nav/rules_swiftnav"
+EXAMPLE_LOCK_DIR = "examples/small_world"
+
+
+def parse_version(module_text):
+    """Return the X.Y.Z version string from a MODULE.bazel module() block."""
+    m = _VERSION_RE.search(module_text)
+    if not m:
+        raise ValueError("no `version = \"X.Y.Z\"` found in MODULE.bazel")
+    return m.group(2)
+
+
+def bump_version(version, part):
+    """Return version with the given semver part incremented."""
+    if part not in _PARTS:
+        raise ValueError(f"part must be one of {_PARTS}, got {part!r}")
+    major, minor, patch = (int(x) for x in version.split("."))
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def set_version(module_text, new_version):
+    """Return module_text with the module() version replaced."""
+    new_text, n = _VERSION_RE.subn(rf"\g<1>{new_version}\g<3>", module_text, count=1)
+    if n != 1:
+        raise ValueError("could not substitute version in MODULE.bazel")
+    return new_text
+
+
+def read_current_version(path="MODULE.bazel", use_stdin=False):
+    """Read MODULE.bazel (from path or stdin) and return its version."""
+    text = sys.stdin.read() if use_stdin else open(path, encoding="utf-8").read()
+    return parse_version(text)
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, check=True, text=True, **kw)
+
+
+def _git_out(cmd):
+    return subprocess.run(["git", *cmd], check=True, text=True,
+                          capture_output=True).stdout.strip()
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Bump version and open a release PR.")
+    p.add_argument("part", nargs="?", choices=_PARTS, help="semver part to bump")
+    p.add_argument("--current", action="store_true",
+                   help="print the current version and exit (used by CI)")
+    p.add_argument("--file", default="MODULE.bazel")
+    p.add_argument("--stdin", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args(argv)
+
+    # Run from the workspace root, not the bazel execroot.
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+    if workspace:
+        os.chdir(workspace)
+
+    if args.current:
+        print(read_current_version(None if args.stdin else args.file, args.stdin))
+        return 0
+
+    if not args.part:
+        p.error("a bump part (major/minor/patch) is required")
+
+    if _git_out(["status", "--porcelain"]):
+        raise SystemExit("working tree is dirty; commit or stash first")
+
+    text = open(args.file, encoding="utf-8").read()
+    old = parse_version(text)
+    new = bump_version(old, args.part)
+    branch = f"release/{new}"
+    tag = f"v{new}"
+
+    existing_tags = _git_out(["tag", "--list", tag])
+    if existing_tags:
+        raise SystemExit(f"tag {tag} already exists")
+
+    if args.dry_run:
+        print(f"[dry-run] {old} -> {new} (branch {branch}, tag {tag})")
+        return 0
+
+    try:
+        with open(args.file, "w", encoding="utf-8") as f:
+            f.write(set_version(text, new))
+
+        # Keep the committed example lockfile in sync with the bumped version.
+        _run(["bazel", "mod", "deps", "--lockfile_mode=update"], cwd=EXAMPLE_LOCK_DIR)
+        # Normalize formatting.
+        _run(["bazel", "run", "//tools/buildifier:buildifier"])
+
+        _run(["git", "checkout", "-b", branch])
+        _run(["git", "add", "MODULE.bazel", f"{EXAMPLE_LOCK_DIR}/MODULE.bazel.lock"])
+        _run(["git", "commit", "-m", f"Bump version to {new}"])
+        _run(["git", "push", "-u", "origin", branch])
+        _run(["gh", "pr", "create", "--repo", REPO, "--fill",
+              "--title", f"Bump version to {new}"])
+        print(f"Opened release PR for {new}.")
+        return 0
+    except Exception:
+        print(
+            f"release failed mid-way. To reset:\n"
+            f"  git checkout main && git branch -D {branch} 2>/dev/null; "
+            f"git checkout -- {args.file} {EXAMPLE_LOCK_DIR}/MODULE.bazel.lock",
+            file=sys.stderr,
+        )
+        raise
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_test.py
+++ b/tools/release_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (C) 2022 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+"""Tests for release.py. Run with: bazel test //tools:release_test"""
+
+import io
+import unittest
+from unittest import mock
+
+from tools.release import bump_version, parse_version, read_current_version, set_version
+
+MODULE = '''module(
+    name = "rules_swiftnav",
+    version = "0.20.0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "platforms", version = "1.0.0")
+'''
+
+
+class ParseVersionTest(unittest.TestCase):
+    def test_reads_version_from_module_block(self):
+        self.assertEqual(parse_version(MODULE), "0.20.0")
+
+    def test_raises_when_missing(self):
+        with self.assertRaises(ValueError):
+            parse_version('module(name = "x")\n')
+
+
+class BumpVersionTest(unittest.TestCase):
+    def test_patch(self):
+        self.assertEqual(bump_version("0.20.0", "patch"), "0.20.1")
+
+    def test_minor(self):
+        self.assertEqual(bump_version("0.20.3", "minor"), "0.21.0")
+
+    def test_major(self):
+        self.assertEqual(bump_version("0.20.3", "major"), "1.0.0")
+
+    def test_rejects_bad_part(self):
+        with self.assertRaises(ValueError):
+            bump_version("0.20.0", "huge")
+
+
+class SetVersionTest(unittest.TestCase):
+    def test_replaces_only_module_version(self):
+        out = set_version(MODULE, "0.21.0")
+        self.assertEqual(parse_version(out), "0.21.0")
+        self.assertIn('compatibility_level = 1', out)
+
+    def test_leaves_bazel_dep_versions_untouched(self):
+        out = set_version(MODULE, "0.21.0")
+        self.assertEqual(parse_version(out), "0.21.0")
+        self.assertIn('version = "1.8.2"', out)
+        self.assertIn('version = "1.0.0"', out)
+
+    def test_idempotent_round_trip(self):
+        self.assertEqual(parse_version(set_version(MODULE, "9.9.9")), "9.9.9")
+
+
+class ReadCurrentVersionTest(unittest.TestCase):
+    def test_reads_from_stdin(self):
+        with mock.patch("sys.stdin", io.StringIO(MODULE)):
+            self.assertEqual(read_current_version(path=None, use_stdin=True), "0.20.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/release_test.py
+++ b/tools/release_test.py
@@ -19,6 +19,9 @@ from unittest import mock
 from tools.release import (
     bump_copyrights,
     bump_version,
+    check_pinned_bazel,
+    parse_bazel_version,
+    parse_bazelisk_pin,
     parse_version,
     read_current_version,
     set_copyright_years,
@@ -145,6 +148,50 @@ class BumpCopyrightsTest(unittest.TestCase):
                 f.write(b"\xff\xfe\x00\x01")
             with mock.patch("tools.release.list_tracked_files", return_value=[binary]):
                 self.assertEqual(bump_copyrights(2026), [])
+
+
+class ParseBazeliskPinTest(unittest.TestCase):
+    def test_reads_pinned_version(self):
+        self.assertEqual(parse_bazelisk_pin("USE_BAZEL_VERSION=9.1.1\n"), "9.1.1")
+
+    def test_tolerates_whitespace_and_other_lines(self):
+        text = "# comment\nBAZELISK_BASE_URL=x\n USE_BAZEL_VERSION = 9.1.1 \n"
+        self.assertEqual(parse_bazelisk_pin(text), "9.1.1")
+
+    def test_returns_none_when_absent(self):
+        self.assertIsNone(parse_bazelisk_pin("BAZELISK_BASE_URL=x\n"))
+
+
+class ParseBazelVersionTest(unittest.TestCase):
+    def test_extracts_semver(self):
+        self.assertEqual(parse_bazel_version("bazel 9.1.1\n"), "9.1.1")
+
+    def test_ignores_trailing_noise(self):
+        self.assertEqual(parse_bazel_version("bazel 9.1.1-homebrew\nextra\n"), "9.1.1")
+
+    def test_returns_none_when_unparseable(self):
+        self.assertIsNone(parse_bazel_version("no version here\n"))
+
+
+class CheckPinnedBazelTest(unittest.TestCase):
+    def test_passes_when_versions_match(self):
+        check_pinned_bazel("9.1.1", "bazel 9.1.1\n")  # no raise
+
+    def test_raises_when_versions_differ(self):
+        with self.assertRaises(SystemExit) as cm:
+            check_pinned_bazel("9.1.1", "bazel 9.0.0\n")
+        self.assertIn("9.1.1", str(cm.exception))
+        self.assertIn("bazelisk", str(cm.exception))
+
+    def test_raises_when_bazel_version_unparseable(self):
+        with self.assertRaises(SystemExit):
+            check_pinned_bazel("9.1.1", "weird output\n")
+
+    def test_noop_when_pin_is_not_concrete(self):
+        check_pinned_bazel("latest", "bazel 9.0.0\n")  # nothing to enforce
+
+    def test_noop_when_pin_is_missing(self):
+        check_pinned_bazel(None, "bazel 9.0.0\n")  # nothing to enforce
 
 
 class ReadCurrentVersionTest(unittest.TestCase):

--- a/tools/release_test.py
+++ b/tools/release_test.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Copyright (C) 2022 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
@@ -11,10 +11,19 @@
 """Tests for release.py. Run with: bazel test //tools:release_test"""
 
 import io
+import os
+import tempfile
 import unittest
 from unittest import mock
 
-from tools.release import bump_version, parse_version, read_current_version, set_version
+from tools.release import (
+    bump_copyrights,
+    bump_version,
+    parse_version,
+    read_current_version,
+    set_copyright_years,
+    set_version,
+)
 
 MODULE = '''module(
     name = "rules_swiftnav",
@@ -65,6 +74,77 @@ class SetVersionTest(unittest.TestCase):
 
     def test_idempotent_round_trip(self):
         self.assertEqual(parse_version(set_version(MODULE, "9.9.9")), "9.9.9")
+
+
+class SetCopyrightYearsTest(unittest.TestCase):
+    HEADER = "# Copyright (C) {} Swift Navigation Inc.\n"
+
+    def test_single_year_becomes_range(self):
+        out = set_copyright_years(self.HEADER.format("2022"), 2026)
+        self.assertEqual(out, self.HEADER.format("2022-2026"))
+
+    def test_extends_existing_range_end(self):
+        out = set_copyright_years(self.HEADER.format("2022-2025"), 2026)
+        self.assertEqual(out, self.HEADER.format("2022-2026"))
+
+    def test_single_year_already_current_is_unchanged(self):
+        text = self.HEADER.format("2026")
+        self.assertEqual(set_copyright_years(text, 2026), text)
+
+    def test_range_already_current_is_idempotent(self):
+        text = self.HEADER.format("2022-2026")
+        self.assertEqual(set_copyright_years(text, 2026), text)
+
+    def test_leaves_non_swiftnav_copyright_untouched(self):
+        text = "# Copyright (C) 2019 Some Other Corp.\n"
+        self.assertEqual(set_copyright_years(text, 2026), text)
+
+    def test_updates_every_header_in_text(self):
+        text = self.HEADER.format("2022") + self.HEADER.format("2023-2024")
+        expected = self.HEADER.format("2022-2026") + self.HEADER.format("2023-2026")
+        self.assertEqual(set_copyright_years(text, 2026), expected)
+
+
+class BumpCopyrightsTest(unittest.TestCase):
+    # Built via format() so the source has no literal "(C) <year> Swift
+    # Navigation" header for the release tool itself to rewrite.
+    HEADER = "# Copyright (C) {} Swift Navigation Inc.\n"
+
+    def _write(self, d, name, text):
+        path = os.path.join(d, name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        return path
+
+    def test_rewrites_only_changed_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            stale = self._write(d, "a.py", self.HEADER.format("2022"))
+            current = self._write(d, "b.py", self.HEADER.format("2022-2026"))
+            no_header = self._write(d, "c.txt", "nothing here\n")
+            with mock.patch("tools.release.list_tracked_files",
+                            return_value=[stale, current, no_header]):
+                changed = bump_copyrights(2026)
+            self.assertEqual(changed, [stale])
+            with open(stale, encoding="utf-8") as f:
+                self.assertEqual(f.read(), self.HEADER.format("2022-2026"))
+
+    def test_dry_run_reports_without_writing(self):
+        with tempfile.TemporaryDirectory() as d:
+            original = self.HEADER.format("2022")
+            stale = self._write(d, "a.py", original)
+            with mock.patch("tools.release.list_tracked_files", return_value=[stale]):
+                changed = bump_copyrights(2026, dry_run=True)
+            self.assertEqual(changed, [stale])
+            with open(stale, encoding="utf-8") as f:
+                self.assertEqual(f.read(), original)
+
+    def test_skips_binary_or_undecodable_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            binary = os.path.join(d, "blob.bin")
+            with open(binary, "wb") as f:
+                f.write(b"\xff\xfe\x00\x01")
+            with mock.patch("tools.release.list_tracked_files", return_value=[binary]):
+                self.assertEqual(bump_copyrights(2026), [])
 
 
 class ReadCurrentVersionTest(unittest.TestCase):

--- a/tools/valgrind/BUILD.bazel
+++ b/tools/valgrind/BUILD.bazel
@@ -1,8 +1,8 @@
-# Copyright (C) 2026 Swift Navigation Inc.
+# Copyright (C) 2022-2026 Swift Navigation Inc.
 # Contact: Swift Navigation <dev@swift-nav.com>
 #
 # This source is subject to the license found in the file 'LICENSE' which must
-# be be distributed together with this source. All other rights reserved.
+# be distributed together with this source. All other rights reserved.
 #
 # THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED


### PR DESCRIPTION
## What

Adds a near-one-command release flow for `rules_swiftnav`.

**`bazel run //tools:release -- major|minor|patch`** — bumps `version` in
`MODULE.bazel`, refreshes `examples/small_world/MODULE.bazel.lock`, and opens a
release PR. Supports `--dry-run`. `--current` prints the current version and is
reused by CI.

**`.github/workflows/release.yaml`** — on push to `main`, detects the
`MODULE.bazel` version change (vs `github.event.before`) and creates the
`vX.Y.Z` tag + GitHub release. Uses only the built-in `GITHUB_TOKEN`,
fork-guarded, and idempotent (skips if unchanged or if the tag already exists).

Publishing the module to the downstream Bazel registry remains a separate manual
step — see `docs/RELEASING.md`.

## Notes

- `tools/release.py` is stdlib-only so CI runs it with plain `python3`.
- The version regex is anchored to the `module()` block so `bazel_dep` versions
  are never touched (covered by `//tools:release_test`).
- See the `GITHUB_TOKEN` breadcrumb comment in the workflow: events it creates
  won't trigger other workflows; switch to a GitHub App token if that's ever
  needed.

## Test plan

- [x] `bazel test //tools:release_test` (version parse/bump/set, --current)
- [x] `bazel run //tools:release -- minor --dry-run` → `0.20.0 -> 0.21.0`
- [x] Detection logic verified on real history (0.19.0→0.20.0 releases; unchanged commit skips; existing-tag guard skips)