### PR TITLE
Require gh CLI on PATH for releases and give the release PR a body

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -3,6 +3,22 @@
 Cutting a release is two steps for a maintainer; the tag and GitHub release are
 created automatically.
 
+## Prerequisites
+
+The release tool shells out to a few command-line tools, which must be on your
+`PATH`:
+
+- **`bazelisk`** (the repo's `bazel` wrapper) — runs the tool and regenerates
+  the example lockfile with the Bazel version pinned in `.bazeliskrc` (see
+  step 1 for why this matters).
+- **`git`** — commits the version bump and pushes the release branch.
+- **`gh`** ([GitHub CLI](https://cli.github.com)), authenticated via
+  `gh auth login` — opens the release PR. The tool checks for it up front and
+  exits with an actionable message if it is missing.
+
+You also need push access to `swift-nav/rules_swiftnav` and a clean working
+tree (the tool refuses to run if there are uncommitted changes).
+
 ## 1. Open the release PR
 
 ```bash

--- a/tools/release.py
+++ b/tools/release.py
@@ -244,8 +244,17 @@ def main(argv=None):
               *bumped])
         _run(["git", "commit", "-m", f"Bump version to {new}"])
         _run(["git", "push", "-u", "origin", branch])
-        _run(["gh", "pr", "create", "--repo", REPO, "--fill",
-              "--title", f"Bump version to {new}"])
+        body = (
+            f"Automated release PR opened by `bazel run //tools:release`.\n\n"
+            f"- Bumps the module version: `{old}` -> `{new}`\n"
+            f"- Refreshes the example lockfile "
+            f"(`{EXAMPLE_LOCK_DIR}/MODULE.bazel.lock`)\n"
+            f"- Extends Swift Navigation copyright headers to {year}\n\n"
+            f"Merging to `main` triggers `.github/workflows/release.yaml`, "
+            f"which tags `{tag}` and creates the GitHub release."
+        )
+        _run(["gh", "pr", "create", "--repo", REPO,
+              "--title", f"Bump version to {new}", "--body", body])
         print(f"Opened release PR for {new}.")
         return 0
     except Exception:

--- a/tools/release.py
+++ b/tools/release.py
@@ -17,6 +17,7 @@ import argparse
 import datetime
 import os
 import re
+import shutil
 import subprocess
 import sys
 
@@ -157,6 +158,20 @@ def _git_out(cmd):
                           capture_output=True).stdout.strip()
 
 
+def require_gh():
+    """Fail early if the GitHub CLI (used to open the release PR) is missing.
+
+    Like `git` and `bazel`, `gh` is expected on the maintainer's PATH; this
+    just turns a late, cryptic "command not found" into an actionable message
+    before any of the release mutations below run.
+    """
+    if shutil.which("gh") is None:
+        raise SystemExit(
+            "gh CLI is required to open the release PR; install it from "
+            "https://cli.github.com and authenticate with `gh auth login`"
+        )
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(description="Bump version and open a release PR.")
     p.add_argument("part", nargs="?", choices=_PARTS, help="semver part to bump")
@@ -199,6 +214,9 @@ def main(argv=None):
         print(f"[dry-run] {old} -> {new} (branch {branch}, tag {tag})")
         print(f"[dry-run] would bump copyright year to {year} in {len(stale)} file(s)")
         return 0
+
+    # Fail before mutating anything if the tool that opens the PR is absent.
+    require_gh()
 
     # The example lockfile is regenerated below; ensure we'll do so with the
     # same Bazel version CI uses, i.e. that bazelisk honored .bazeliskrc.

--- a/tools/release_test.py
+++ b/tools/release_test.py
@@ -24,6 +24,7 @@ from tools.release import (
     parse_bazelisk_pin,
     parse_version,
     read_current_version,
+    require_gh,
     set_copyright_years,
     set_version,
 )
@@ -192,6 +193,18 @@ class CheckPinnedBazelTest(unittest.TestCase):
 
     def test_noop_when_pin_is_missing(self):
         check_pinned_bazel(None, "bazel 9.0.0\n")  # nothing to enforce
+
+
+class RequireGhTest(unittest.TestCase):
+    def test_passes_when_gh_on_path(self):
+        with mock.patch("tools.release.shutil.which", return_value="/usr/bin/gh"):
+            require_gh()  # no raise
+
+    def test_raises_when_gh_missing(self):
+        with mock.patch("tools.release.shutil.which", return_value=None):
+            with self.assertRaises(SystemExit) as cm:
+                require_gh()
+        self.assertIn("gh", str(cm.exception))
 
 
 class ReadCurrentVersionTest(unittest.TestCase):


### PR DESCRIPTION
## What

The `release.py` tool shells out to `gh` to open the release PR but never checked for it, so a missing `gh` surfaced only as a cryptic failure *after* the version bump, copyright rewrite, and branch push had already run. This treats `gh` like the script's other `PATH` tools (`git`, `bazel`) — used directly, but now declared explicitly and documented.

## Changes

- **`tools/release.py`**: add a `require_gh()` preflight (`shutil.which`) that fails early with an actionable install/auth message, before any tree mutation. The `--current` and `--dry-run` paths don't require `gh`.
- **`tools/release.py`**: give the release PR an explicit `--body` (version bump, lockfile refresh, copyright update, and the tag/release that merging triggers) instead of `--fill`, which produced an effectively empty body from the lone "Bump version" commit.
- **`tools/release_test.py`**: `RequireGhTest` covering present/absent `gh`.
- **`docs/RELEASING.md`**: new **Prerequisites** section listing `bazelisk`, `git`, and authenticated `gh`, plus push-access / clean-tree requirements.

## Notes

No hermetic vendoring of `gh` — there's no version/checksum table to maintain, and the side-effecting `gh pr create` gains nothing from pinning. Consistent with how `git`/`bazel` are already invoked.

## Verification

- `bazel test //tools:release_test` → PASSED
- `python3 tools/release.py --current` → `0.20.0` (stdlib-only, no `gh` needed)
- `bazel run //tools:release -- --dry-run patch` → exits 0, no `gh` invocation