### PR TITLE
Make work with `rules_rs` bindgen

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@
 
 module(
     name = "rules_swiftnav",
-    version = "0.22.0",
+    version = "0.23.0",
 )
 
 # Core Bazel dependencies

--- a/cc/toolchains/llvm20/cc_toolchain_config.bzl
+++ b/cc/toolchains/llvm20/cc_toolchain_config.bzl
@@ -54,6 +54,13 @@ def cc_toolchain_config(
         "-ffp-contract=off",
         # Diagnostics
         "-fcolor-diagnostics",
+        # Clang's builtin resource include (stdarg.h, stddef.h, ...). The real
+        # clang auto-detects this relative to its own binary, so this is a
+        # no-op there (lowest priority, real dir found first). It's required by
+        # consumers that drive a separate libclang with include-path detection
+        # disabled, e.g. rules_rs hermetic bindgen. Clang major = llvm20.
+        "-idirafter",
+        "{}/lib/clang/20/include".format(toolchain_path_prefix),
     ] + extra_copts
 
     # -fstandalone-debug disables options that optimize

--- a/examples/small_world/MODULE.bazel.lock
+++ b/examples/small_world/MODULE.bazel.lock
@@ -559,7 +559,7 @@
     "@@rules_swiftnav+//cc:extensions.bzl%swift_cc_toolchain_extension": {
       "general": {
         "bzlTransitiveDigest": "LS0VF7klVv3uKgNzF7w5juh0eLqMf5RfufyCxD5bY3g=",
-        "usagesDigest": "NjX574I3NTeA4ktPeTtKVhYLDmy4spS2c/aRx02g9Rw=",
+        "usagesDigest": "SVuUXmKtGjW61IFF3CuuXCUn9YtoaV7LAfvSCL79/A4=",
         "recordedInputs": [
           "REPO_MAPPING:rules_swiftnav+,bazel_tools bazel_tools",
           "REPO_MAPPING:rules_swiftnav+,rules_swiftnav rules_swiftnav+"


### PR DESCRIPTION
Append the clang resource folder at the end of every compilation, so that `rules_rs` hermetic `bindgen` can find builtin/resource headers. (rules_rs disables automatic search of headers, therefore we need to specify it, when using it with our own toolchains. Needed as long as we did not migrate to hermetic-llvm)