### PR TITLE
Support unit switch for valgrind report

### DIFF
--- a/tools/valgrind/report/pr_comment.py
+++ b/tools/valgrind/report/pr_comment.py
@@ -14,9 +14,13 @@ Requirements:
   - The verdict is a symbol plus the reason in words. GitHub strips title
     attributes, so hover tooltips are not an option.
   - Blocks are sorted by label, so rewriting the comment never reshuffles them.
+  - Byte quantities can be rendered in a unit of the reader's choosing, for a
+    target whose figures are far from the one they were measured in: a decoder
+    peaking at 215 bytes of heap extra is "0.000 MB" but "0.210 KB".
 
 Run with Bazel:
     bazel run //tools/valgrind/report:pr_comment -- --commit abc1234 \\
+        --unit KB \\
         /abs/path/a/valgrind-callgrind.report.json \\
         /abs/path/b/valgrind-callgrind.report.json
 """
@@ -42,6 +46,11 @@ from tools.valgrind.report.metrics import (
 DEFAULT_MARKER = "<!-- valgrind-callgrind-regression -->"
 DEFAULT_TITLE = "Valgrind analysis"
 
+# A metric measured in one of these converts to any other by ratio. Everything
+# else — an instruction count, whose unit is empty — is left as measured.
+_UNIT_BYTES = {"B": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3}
+UNITS = sorted(_UNIT_BYTES)
+
 METRIC_HEADER = "\n".join(
     [
         "| Metric | Value | Baseline | Delta |",
@@ -61,6 +70,41 @@ _STATUS_WORDING = {
     STATUS_STALE_BASELINE: "baseline stale",
     STATUS_OVER_LIMIT: "over limit",
 }
+
+
+def convert_metric(metric: Metric, unit: str) -> Metric:
+    """Rescale a byte quantity to unit, leaving anything else as measured.
+
+    Only the absolute numbers move; delta_pct and tolerance_pct are ratios and
+    mean the same in any unit.
+    """
+    source = metric["unit"]
+    if source == unit or source not in _UNIT_BYTES:
+        return metric
+
+    factor = _UNIT_BYTES[source] / _UNIT_BYTES[unit]
+    converted = dict(metric)
+    for key in ("value", "baseline", "delta", "max"):
+        if converted[key] is not None:
+            converted[key] *= factor
+    converted["unit"] = unit
+    return Metric(**converted)
+
+
+def convert_report(report: Report, unit: str | None) -> Report:
+    """Render every byte quantity of a report in unit, or as measured if None.
+
+    Display only: the baseline file the block points at keeps the unit it was
+    written in, which is the one a refresh has to be typed back in.
+    """
+    if unit is None:
+        return report
+
+    converted = dict(report)
+    converted["metrics"] = [
+        convert_metric(metric, unit) for metric in report["metrics"]
+    ]
+    return Report(**converted)
 
 
 def format_percent(pct: float) -> str:
@@ -182,10 +226,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--commit", default=None, help="Commit SHA quoted in the footer"
     )
+    parser.add_argument(
+        "--unit",
+        default=None,
+        choices=UNITS,
+        help="Render byte quantities in this unit instead of the one they were "
+        "measured in. Leave unset to keep the measured unit",
+    )
     args = parser.parse_args(argv)
 
     try:
-        reports = [read_report(path) for path in args.reports]
+        reports = [
+            convert_report(read_report(path), args.unit) for path in args.reports
+        ]
     except (OSError, ValueError) as err:
         print(f"Error: could not read a valgrind report: {err}", file=sys.stderr)
         return 1

--- a/tools/valgrind/report/pr_comment_test.py
+++ b/tools/valgrind/report/pr_comment_test.py
@@ -20,6 +20,8 @@ from tools.valgrind.report.metrics import (
 from tools.valgrind.report.pr_comment import (
     DEFAULT_MARKER,
     METRIC_HEADER,
+    convert_metric,
+    convert_report,
     format_comment,
     format_percent,
     main,
@@ -163,6 +165,58 @@ class FormatCommentTest(unittest.TestCase):
         self.assertIn("tolerance per metric", comment)
 
 
+class ConvertUnitTest(unittest.TestCase):
+    def test_rescales_every_absolute_number_but_no_percentage(self) -> None:
+        heap = build_metric("memory_heap_mb", "Peak heap", "MB", 2.0, 1.0, 5.0, 4.0)
+
+        converted = convert_metric(heap, "KB")
+
+        self.assertEqual(converted["unit"], "KB")
+        self.assertEqual(converted["value"], 2048.0)
+        self.assertEqual(converted["baseline"], 1024.0)
+        self.assertEqual(converted["delta"], 1024.0)
+        self.assertEqual(converted["max"], 4096.0)
+        self.assertEqual(converted["delta_pct"], heap["delta_pct"])
+        self.assertEqual(converted["tolerance_pct"], heap["tolerance_pct"])
+
+    def test_leaves_a_metric_that_is_not_a_byte_quantity_alone(self) -> None:
+        instructions = build_metric(
+            "cpu_instructions", "CPU instructions", "", 1050, 1000, 5.0
+        )
+
+        self.assertEqual(convert_metric(instructions, "KB"), instructions)
+
+    def test_a_metric_without_a_ceiling_keeps_none(self) -> None:
+        heap = build_metric("memory_heap_mb", "Peak heap", "MB", 2.0, 1.0, 5.0)
+
+        self.assertIsNone(convert_metric(heap, "KB")["max"])
+
+    def test_report_without_a_unit_is_returned_as_measured(self) -> None:
+        report = _report("run_replay", 1050, 1000)
+
+        self.assertEqual(convert_report(report, None), report)
+
+    def test_a_sub_mb_figure_reads_as_kb_in_the_table(self) -> None:
+        # 215 bytes of heap extra: "0.000 MB" says nothing, "0.210 KB" does.
+        extra = build_metric(
+            "memory_heap_extra_mb",
+            "Peak heap extra (massif)",
+            "MB",
+            215 / 1024**2,
+            0.0002,
+            5.0,
+        )
+        report = build_report("massif_target", "pkg/baseline.json", [extra])
+
+        as_measured = format_comment([report], DEFAULT_MARKER, "Title", None)
+        as_kb = format_comment(
+            [convert_report(report, "KB")], DEFAULT_MARKER, "Title", None
+        )
+
+        self.assertIn("| 0.000 MB |", as_measured)
+        self.assertIn("| 0.210 KB |", as_kb)
+
+
 class MainTest(unittest.TestCase):
     def test_merges_every_report_given(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -179,6 +233,24 @@ class MainTest(unittest.TestCase):
             self.assertIn("<summary>✅ <code>first</code></summary>", comment)
             self.assertIn("<summary>✅ <code>second</code></summary>", comment)
             self.assertEqual(comment.count("<details open>"), 2)
+
+    def test_unit_flag_converts_the_reports_it_reads(self) -> None:
+        heap = build_metric("memory_heap_mb", "Peak heap", "MB", 2.0, 1.0, 5.0)
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "massif.json"
+            write_report(
+                build_report("massif_target", "pkg/baseline.json", [heap]), path
+            )
+
+            out = io.StringIO()
+            with redirect_stdout(out):
+                exit_code = main([str(path), "--unit", "KB"])
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn(
+                "| Peak heap | 2,048.000 KB | 1,024.000 KB | +1,024.000 KB (+100.00%) |",
+                out.getvalue(),
+            )
 
     def test_fails_on_an_unreadable_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Allow `--unit KB` for `//tools/valgrind/report:pr_comment`